### PR TITLE
Fix Timer Size Overflow on pomodoro.html

### DIFF
--- a/assets/css/pomodoro.css
+++ b/assets/css/pomodoro.css
@@ -134,11 +134,10 @@ body {
 /*-----------circle---------------------------------------------------------------------*/
 .timer-container {
     position: relative;
-    top: 0.5cm;
-    position: relative;
-    width: min(80vw, 600px);
-    height: min(80vw, 600px);
-    margin: 2rem auto;
+    margin-top: 0;
+    width: min(80vw, 400px);
+    height: min(80vw, 400px);
+    /
 }
 
 .timer-circle {
@@ -181,7 +180,7 @@ body {
 }
 
 .time-display {
-    font-size: clamp(3rem, 10vw, 8rem);
+    font-size: clamp(2rem, 10vw, 5rem);
     font-weight: bold;
     z-index: 2;
     text-shadow: 0 0 20px rgba(0, 179, 255, 0.5);

--- a/pages/pomodoro.html
+++ b/pages/pomodoro.html
@@ -116,7 +116,7 @@
             <!-- Timer Container -->
             <div class="timer-container">
                 <div class="timer-circle">
-                    <svg class="progress-ring" width="100%" height="100%" viewBox="0 0 400 400">
+                    <svg class="progress-ring" width="70%" height="70%" viewBox="0 0 400 400">
                         <circle 
                             class="outer-circle" 
                             cx="200" 


### PR DESCRIPTION
### Summary
The timer displayed on pomodoro.html was significantly larger than necessary, causing the Start, Pause, and Reset buttons to be pushed out of view on certain screen sizes. This update reduces the timer size so the entire interface fits comfortably within a single screen.

### Fixes: #142 

### Problem
The circular timer consumed most of the page height.
Control buttons were forced below the visible area, requiring users to scroll.
The overly large timer negatively impacted usability and accessibility.

### Solution
Adjusted the timer dimensions to ensure it scales appropriately across screen sizes.
Ensured the Start, Pause, and Reset buttons remain visible in single frame.

### Result
The timer and its controls now fit within a single screen, providing a cleaner and more accessible user experience.

### Before:
<img width="800" height="900" alt="image" src="https://github.com/user-attachments/assets/9c4f33cf-a5a6-4080-951e-2fc009d6be55" />

### After:
<img width="800" height="900" alt="image" src="https://github.com/user-attachments/assets/d261ac58-4ee1-4f06-b536-28682bb08095" />

