### PR TITLE
Fix: Modified the theme for the elements in the pomodoro page

### DIFF
--- a/assets/css/pomodoro.css
+++ b/assets/css/pomodoro.css
@@ -291,7 +291,7 @@ body {
 .music-section {
     width: 100%;
     max-width: 600px;
-    background-color: var(--card-bg);
+    background: var(--card-bg);
     border-radius: 10px;
     padding: 2rem;
     position: relative;
@@ -343,7 +343,7 @@ body {
 .stats-panel {
     width: 100%;
     max-width: 600px;
-    background-color: var(--card-bg);
+    background: var(--card-bg);
     border-radius: 10px;
     padding: 2rem;
     margin-top: 2rem;


### PR DESCRIPTION
## Pull Request Summary
Fixes https://github.com/mugenkyou/College_daddy/issues/165
* Aligned the page's theme to whole application
---

## Changes Introduced
- Changed the background color of the elements in the pomodoro page to that used in the Roadmap page

---

## Screenshots / Demo (for UI changes)
Before
<img width="1896" height="987" alt="image" src="https://github.com/user-attachments/assets/295b5287-82c2-4a1b-9ca3-cb608363ca92" />
After
<img width="1900" height="1049" alt="image" src="https://github.com/user-attachments/assets/8d00a282-1222-4afb-901f-38e948c93473" />

---

## Checklist
Please ensure the following before requesting review:
- [x] Code follows project conventions and best practices.  
- [x] Feature or fix works correctly on both mobile and desktop.  
- [x] No new console errors or accessibility regressions.  
- [x] Documentation updated if applicable.  
- [x] Visuals attached for UI-related updates.  

---