### PR TITLE
Fix styling on roadmap page

### DIFF
--- a/assets/css/roadmap.css
+++ b/assets/css/roadmap.css
@@ -309,7 +309,6 @@ a:hover {
     margin: 3rem auto;
     padding: 3rem 1.5rem;
     max-width: 1200px;
-    background-color: #000;
     color: #fff;
     border-radius: 10px;
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
### Before
<img width="1919" height="914" alt="Screenshot 2026-01-15 140004" src="https://github.com/user-attachments/assets/4fbdf8ab-b062-4544-84ae-28d640cfaae7" />

### After
<img width="1917" height="912" alt="Screenshot 2026-01-15 134011" src="https://github.com/user-attachments/assets/35586e22-c360-4f8d-a6e4-c543c9a0705c" />
<img width="1916" height="897" alt="Screenshot 2026-01-15 134021" src="https://github.com/user-attachments/assets/94d637d5-938c-4241-b4b3-0d691a4b166d" />
