### PR TITLE
update View PDF button theme colors and add Back to Top functionality

### DIFF
--- a/assets/css/notes.css
+++ b/assets/css/notes.css
@@ -222,19 +222,19 @@ nav h1 {
     flex-wrap: wrap;
 }
 
-/* View Button */
+/* View Button - outline style aligned with theme */
 .view-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: #333333;
-    color: var(--text-light);
+    background: var(--primary-dim, rgba(0, 157, 255, 0.15));
+    color: var(--primary-color);
     padding: 0.75rem 1.25rem;
     border-radius: 8px;
     text-decoration: none;
     font-weight: 500;
     transition: all var(--transition-speed) ease;
-    border: none;
+    border: 2px solid var(--primary-color);
     cursor: pointer;
     font-size: 1rem;
     min-width: 120px;
@@ -246,13 +246,16 @@ nav h1 {
 }
 
 .view-btn:hover {
-    background: #444444;
+    background: var(--primary-color);
+    color: var(--text-light);
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 4px 12px rgba(0, 157, 255, 0.3);
 }
 
 .view-btn:active {
-    background: #222222;
+    background: var(--primary-active, #006eb3);
+    border-color: var(--primary-active, #006eb3);
+    color: var(--text-light);
     transform: translateY(0);
 }
 
@@ -480,7 +483,7 @@ nav h1 {
     .card h3 {
         font-size: 1.4rem;
         margin-bottom: 0.8rem;
-    }S
+    }
 
     .card p {
         font-size: 1rem;

--- a/assets/js/components/back-to-top.js
+++ b/assets/js/components/back-to-top.js
@@ -20,42 +20,52 @@ document.addEventListener("DOMContentLoaded", () => {
     style.textContent = `
       .back-to-top-btn {
         position: fixed;
-        right: 1rem;
-        bottom: 1rem;
-        width: 2.75rem;
-        height: 2.75rem;
-        border: 2px solid var(--primary-color, #009dff);
+        pointer-events: none;
+        right: 1.25rem;
+        bottom: 1.25rem;
+        width: 3rem;
+        height: 3rem;
+        border: none;
         border-radius: 999px;
-        background: var(--bg-darker, #0a0a0a);
+        background: var(--primary-color, #009dff);
         color: var(--text-light, #ffffff);
-        font-size: 1.1rem;
+        font-size: 1.25rem;
         cursor: pointer;
         opacity: 0;
         visibility: hidden;
-        transform: translateY(8px);
-        transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
-        z-index: 1000;
+        transform: translateY(12px) scale(0.9);
+        transition: opacity 0.25s ease, transform 0.25s ease, visibility 0.25s ease, background 0.2s ease;
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: 0 4px 16px rgba(0, 157, 255, 0.4);
       }
 
       .back-to-top-btn.visible {
         opacity: 1;
         visibility: visible;
-        transform: translateY(0);
+        transform: translateY(0) scale(1);
+        pointer-events: auto;
       }
 
       .back-to-top-btn:hover {
-        background: var(--card-bg, #181818);
+        background: var(--primary-hover, #00c8ff);
+        box-shadow: 0 6px 20px rgba(0, 157, 255, 0.5);
       }
 
       .back-to-top-btn:focus-visible {
-        outline: 2px solid var(--primary-color, #009dff);
+        outline: 2px solid var(--text-light, #ffffff);
         outline-offset: 3px;
       }
 
       @media (max-width: 768px) {
         .back-to-top-btn {
-          right: 0.85rem;
-          bottom: 0.85rem;
+          right: 1rem;
+          bottom: 1rem;
+          width: 2.75rem;
+          height: 2.75rem;
+          font-size: 1.1rem;
         }
       }
     `;


### PR DESCRIPTION
## Pull Request Summary
This PR fixes the inconsistent View PDF button color and resolves the Back to Top button visibility issue across pages.

The View PDF button now correctly uses the primary theme color in both light and dark modes. Additionally, the Back to Top button appears when scrolling past approximately 220px (excluding the homepage) and functions smoothly across devices.

Fixes #193

---

## Changes Introduced
- Updated View PDF button styling to match the primary theme color in both dark and light modes.
- Implemented Back to Top button visibility after ~220px scroll threshold.
- Ensured Back to Top button is excluded from the homepage.
- Improved alignment and smooth scrolling behavior.
- Verified responsiveness across desktop and mobile breakpoints.

---

## Screenshots 
##Before 
<img width="1409" height="578" alt="image" src="https://github.com/user-attachments/assets/119bb298-c6c5-4e33-a9a3-eeb067d45fdf" />
<img width="116" height="104" alt="image" src="https://github.com/user-attachments/assets/58006771-26d8-4304-903c-0258a1b050d5" />


##After
<img width="1400" height="450" alt="image" src="https://github.com/user-attachments/assets/2af929dc-1577-41ea-9c2f-924e27891c0f" />
<img width="99" height="100" alt="image" src="https://github.com/user-attachments/assets/0a915943-1f14-43d5-bb8d-0f8d5486a927" />
