### PR TITLE
Update study timer

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -19,7 +19,17 @@
   --primary-color: #009dff;
   --primary-hover: #00c8ff;
   --primary-active: #006eb3;
+  --primary-dim: rgba(0, 157, 255, 0.15);
+  --primary-border: rgba(0, 157, 255, 0.25);
   --accent-color: #00c8ff;
+
+  /* Semantic */
+  --success-color: #22c55e;
+  --success-dim: rgba(34, 197, 94, 0.15);
+  --danger-color: #ef4444;
+  --danger-dim: rgba(239, 68, 68, 0.15);
+  --streak-color: #f59e0b;
+  --streak-dim: rgba(245, 158, 11, 0.15);
 
   /* Backgrounds */
   --bg-dark: #000000;
@@ -51,6 +61,12 @@
 /* ============================= */
 
 [data-theme="light"] {
+  --primary-dim: rgba(0, 157, 255, 0.12);
+  --primary-border: rgba(0, 157, 255, 0.35);
+  --success-dim: rgba(34, 197, 94, 0.12);
+  --danger-dim: rgba(239, 68, 68, 0.12);
+  --streak-dim: rgba(245, 158, 11, 0.12);
+
   --bg-dark: #ffffff;
   --bg-darker: #f5f5f5;
   --card-bg: #ffffff;

--- a/assets/css/pomodoro.css
+++ b/assets/css/pomodoro.css
@@ -43,6 +43,17 @@ main {
     position: relative;
 }
 
+/* Header - sticky to top like Home menu navbar */
+body > header {
+    position: sticky !important;
+    top: 0 !important;
+    z-index: 1000 !important;
+    width: 100% !important;
+    background-color: var(--bg-darker) !important;
+    box-shadow: 0 2px 15px rgba(0, 0, 0, 0.3) !important;
+    border-bottom: 1px solid var(--border-color) !important;
+}
+
 /* Navigation Styles - Keep These */
 .menu-button.active {
     background-color: var(--primary-dim);
@@ -58,7 +69,7 @@ body {
     align-items: center;
     color: var(--primary-color);
     overflow-x: hidden;
-    padding: 2rem;
+    padding: 0 1rem 2rem 1rem; /* no top padding so navbar sticks flush to top like Home */
 }
 
 .container {
@@ -68,7 +79,7 @@ body {
     flex-direction: column;
     align-items: center;
     gap: 2rem;
-    padding: 5rem;
+    padding: 2rem 1.5rem;
 }
 
 .title {
@@ -81,12 +92,35 @@ body {
     animation: glow 2s ease-in-out infinite alternate;
 }
 /*-----------circle---------------------------------------------------------------------*/
+/* Timer section card - organizes content and reduces empty space */
+.timer-section {
+    padding: 2rem 1.5rem 3rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+}
+.timer-section-card {
+    width: 100%;
+    max-width: 560px;
+    margin: 0 auto;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius, 16px);
+    padding: 2.5rem 2rem;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+}
 .timer-container {
     position: relative;
     margin-top: 0;
-    width: min(80vw, 500px);
-    height: min(80vw, 500px);
-    /
+    width: min(72vw, 320px);
+    height: min(72vw, 320px);
 }
 
 .timer-circle {
@@ -95,14 +129,15 @@ body {
     height: 100%;
     border-radius: 50%;
     background: radial-gradient(circle at center,
-        var(--bg-dark) 0%,
-        var(--bg-darker) 100%);
+        var(--bg-darker) 0%,
+        var(--card-bg) 70%);
+    border: 3px solid rgba(0, 157, 255, 0.25);
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    box-shadow: 0 0 50px rgba(0, 179, 255, 0.3),
-                inset 0 0 30px rgba(0, 179, 255, 0.2);
+    box-shadow: 0 0 40px rgba(0, 157, 255, 0.2),
+                inset 0 0 24px rgba(0, 157, 255, 0.06);
     animation: pulse 4s ease-in-out infinite;
 }
 
@@ -120,7 +155,7 @@ body {
     stroke: var(--primary-color);
     stroke-width: 8;
     stroke-linecap: round;
-    filter: drop-shadow(0 0 10px var(--primary-color));
+    filter: drop-shadow(0 0 12px rgba(0, 157, 255, 0.5));
     transition: stroke-dashoffset 0.3s ease-in-out, stroke-width 0.3s ease;
 }
 
@@ -129,10 +164,12 @@ body {
 }
 
 .time-display {
-    font-size: clamp(2rem, 10vw, 5rem);
-    font-weight: bold;
+    font-size: clamp(2.5rem, 12vw, 4rem);
+    font-weight: 700;
     z-index: 2;
-    text-shadow: 0 0 20px rgba(0, 179, 255, 0.5);
+    color: var(--text-light);
+    letter-spacing: 0.02em;
+    text-shadow: 0 0 24px rgba(0, 157, 255, 0.4);
     transition: transform 0.3s ease;
 }
 
@@ -141,12 +178,14 @@ body {
 }
 
 .phase-display {
-    font-size: clamp(1rem, 3vw, 1.5rem);
-    margin-top: 1rem;
+    font-size: clamp(0.85rem, 2.5vw, 1.1rem);
+    margin-top: 0.75rem;
     z-index: 2;
     text-transform: uppercase;
-    letter-spacing: 0.2rem;
-    opacity: 0.9;
+    letter-spacing: 0.15em;
+    color: var(--primary-color);
+    font-weight: 600;
+    opacity: 0.95;
     transition: opacity 0.3s ease;
 }
 
@@ -195,60 +234,118 @@ body {
     font-size: 1rem;
 }
 
-/* FIX 3: Controls - all buttons on one line, shifted slightly left to center under timer */
+/* Controls - centered, modern spacing */
 .controls {
-    position: relative;
-    top: 0;
     display: flex;
-    gap: 1rem;
-    margin: 1rem auto;
-    flex-wrap: nowrap;
+    gap: 0.75rem;
+    margin: 0;
+    flex-wrap: wrap;
     justify-content: center;
     width: 100%;
-    transform: translateX(-140px);
+    max-width: 400px;
 }
 
+/* Base button - theme-aligned */
 .btn {
-    
-    padding: 1rem 2rem;
-    font-size: 1.2rem;
-    background: transparent;
-    border: 2px solid var(--primary-color);
-    color: var(--primary-color);
+    padding: 0.85rem 1.5rem;
+    font-size: 0.95rem;
+    font-weight: 600;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all var(--transition-speed, 0.25s) ease;
     text-transform: uppercase;
-    letter-spacing: 0.2rem;
-    border-radius: 5px;
+    letter-spacing: 0.08em;
+    border-radius: 12px;
+    border: 2px solid transparent;
+    min-height: 44px;
 }
-
-.btn:hover {
+/* Primary: Start - filled */
+.btn-primary {
     background: var(--primary-color);
-    color: var(--bg-dark);
-    box-shadow: 0 0 20px var(--primary-color);
+    color: var(--text-light);
+    border-color: var(--primary-color);
+    box-shadow: 0 4px 14px rgba(0, 157, 255, 0.35);
 }
-
+.btn-primary:hover {
+    background: var(--primary-hover);
+    border-color: var(--primary-hover);
+    color: var(--text-light);
+    box-shadow: 0 6px 20px rgba(0, 157, 255, 0.45);
+    transform: translateY(-1px);
+}
+.btn-primary:active {
+    transform: translateY(0);
+    background: var(--primary-active);
+    border-color: var(--primary-active);
+}
+/* Secondary: Skip, Reset - outline */
+.btn-secondary {
+    background: transparent;
+    color: var(--primary-color);
+    border-color: var(--primary-color);
+}
+.btn-secondary:hover {
+    background: rgba(0, 157, 255, 0.12);
+    color: var(--primary-hover);
+    border-color: var(--primary-hover);
+    transform: translateY(-1px);
+}
+.btn-secondary:active {
+    transform: translateY(0);
+    background: rgba(0, 157, 255, 0.18);
+}
 .btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+    transform: none !important;
+}
+/* Pause state - when timer is running (JS adds .btn-pause) */
+.btn-primary.btn-pause {
+    background: rgba(255, 68, 68, 0.2);
+    border-color: #e55555;
+    color: #ff6b6b;
+    box-shadow: 0 4px 14px rgba(229, 85, 85, 0.25);
+}
+.btn-primary.btn-pause:hover {
+    background: rgba(255, 68, 68, 0.3);
+    border-color: #ff6b6b;
+    color: #ff8888;
+    box-shadow: 0 6px 20px rgba(229, 85, 85, 0.35);
+}
+/* Buttons without .btn-primary/.btn-secondary (e.g. Apply Settings, Load Music) */
+.btn:not(.btn-primary):not(.btn-secondary) {
+    background: transparent;
+    color: var(--primary-color);
+    border-color: var(--primary-color);
+}
+.btn:not(.btn-primary):not(.btn-secondary):hover {
+    background: rgba(0, 157, 255, 0.12);
+    color: var(--primary-hover);
+    border-color: var(--primary-hover);
 }
 
-/* FIX 1: Music section - changed top:4cm to margin-top:4cm so it pushes content below */
+/* Music section - directly below timer, centered */
+.timer-section .music-section {
+    width: 100%;
+    margin-top: 1.5rem;
+}
 .music-section {
     width: 100%;
     max-width: 600px;
     background: var(--card-bg);
-    border-radius: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius, 16px);
     padding: 2rem;
     position: relative;
     top: 0;
-    margin-top: 4cm;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
 .music-title {
     font-size: 1.5rem;
     margin-bottom: 1rem;
     text-align: center;
+    color: var(--primary-color);
+    font-weight: 600;
 }
 
 .music-controls {
@@ -366,27 +463,36 @@ body {
 /* Animations */
 @keyframes pulse {
     0% {
-        transform: scale(0.95);
-        box-shadow: 0 0 50px rgba(0, 179, 255, 0.3),
-                    inset 0 0 30px rgba(0, 179, 255, 0.2);
+        transform: scale(0.98);
+        box-shadow: 0 0 40px rgba(0, 157, 255, 0.2),
+                    inset 0 0 24px rgba(0, 157, 255, 0.06);
     }
     50% {
         transform: scale(1);
-        box-shadow: 0 0 50px rgba(0, 179, 255, 0.5),
-                    inset 0 0 30px rgba(0, 179, 255, 0.3);
+        box-shadow: 0 0 48px rgba(0, 157, 255, 0.28),
+                    inset 0 0 28px rgba(0, 157, 255, 0.08);
     }
     100% {
-        transform: scale(0.95);
-        box-shadow: 0 0 50px rgba(0, 179, 255, 0.3),
-                    inset 0 0 30px rgba(0, 179, 255, 0.2);
+        transform: scale(0.98);
+        box-shadow: 0 0 40px rgba(0, 157, 255, 0.2),
+                    inset 0 0 24px rgba(0, 157, 255, 0.06);
     }
 }
 
 @media (max-width: 600px) {
+    .timer-section-card {
+        padding: 1.75rem 1.25rem;
+        gap: 1.5rem;
+    }
+    .controls {
+        flex-direction: column;
+        width: 100%;
+        max-width: 100%;
+    }
     .btn {
         width: 100%;
-        font-size: 1rem;
-        padding: 0.8rem 1rem;
+        font-size: 0.9rem;
+        padding: 0.85rem 1.25rem;
     }
 }
 /* Accessibility and Touch Improvements */
@@ -440,27 +546,68 @@ html {
     } */
 
     
-    .settings-icon {
-        
-        position: fixed;
-        top: 80px;
-        right: 20px;
-        width: 40px;
-        height: 40px;
-        background: var(--bg-dark);
-        border: 2px solid var(--primary-color);
-        border-radius: 50%;
-        cursor: pointer;
+    /* Timer controls on navbar (Study Timer page only) */
+    .timer-nav-controls {
         display: flex;
         align-items: center;
-        justify-content: center;
-        z-index: 1000;
-        transition: transform 0.3s ease;
+        gap: 8px;
     }
-
-    .settings-icon:hover {
+    body > header .settings-icon {
+        position: relative !important;
+        top: auto !important;
+        right: auto !important;
+        left: auto !important;
+        width: 40px !important;
+        height: 40px !important;
+        min-width: 40px !important;
+        background: transparent !important;
+        border: 2px solid var(--primary-color) !important;
+        border-radius: 50% !important;
+        cursor: pointer;
+        display: flex !important;
+        align-items: center;
+        justify-content: center;
+        transition: transform 0.3s ease, background 0.2s ease, color 0.2s ease;
+        flex-shrink: 0;
+    }
+    body > header .settings-icon:hover {
+        background: var(--primary-color) !important;
         transform: rotate(45deg);
     }
+
+/* Fullscreen button - on navbar, match theme toggle style */
+body > header .fullscreen-btn {
+    width: 40px !important;
+    height: 40px !important;
+    min-width: 40px !important;
+    padding: 0 !important;
+    background: transparent !important;
+    border: 2px solid var(--primary-color) !important;
+    border-radius: 50% !important;
+    color: var(--primary-color);
+    cursor: pointer;
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.25s ease;
+    box-shadow: none;
+}
+body > header .fullscreen-btn svg {
+    width: 16px;
+    height: 16px;
+}
+body > header .fullscreen-btn span {
+    display: none;
+}
+body > header .fullscreen-btn:hover {
+    background: var(--primary-color) !important;
+    color: var(--text-light);
+    transform: scale(1.1);
+    box-shadow: 0 2px 8px rgba(0, 157, 255, 0.3);
+}
+body > header .fullscreen-btn:active {
+    transform: scale(0.95);
+}
 
     .settings-icon::before {
         content: "⚙️";
@@ -468,8 +615,8 @@ html {
     }
 
     .settings-panel {
-        position: fixed;
-        top: 70px;
+        position: fixed !important;
+        top: 64px;
         right: 20px;
         width: 300px;
         background: var(--card-bg);

--- a/assets/js/pages/pomodoro.js
+++ b/assets/js/pages/pomodoro.js
@@ -211,8 +211,7 @@ class PomodoroTimer {
         this.pausedTime = null;
         if (this.startBtn) {
             this.startBtn.textContent = 'Start';
-            this.startBtn.style.backgroundColor = '';
-            this.startBtn.style.borderColor = '';
+            this.startBtn.classList.remove('btn-pause');
         }
         this.currentPhase = 'work';
         this.remainingTime = this.settings.workDuration * 60 * 1000;
@@ -236,8 +235,7 @@ class PomodoroTimer {
         this.isRunning = true;
         if (this.startBtn) {
             this.startBtn.textContent = 'Pause';
-            this.startBtn.style.backgroundColor = 'rgba(255, 0, 0, 0.1)';
-            this.startBtn.style.borderColor = '#ff4444';
+            this.startBtn.classList.add('btn-pause');
         }
 
         if (this.pausedTime) {
@@ -265,8 +263,7 @@ class PomodoroTimer {
         clearInterval(this.interval);
         if (this.startBtn) {
             this.startBtn.textContent = 'Resume';
-            this.startBtn.style.backgroundColor = '';
-            this.startBtn.style.borderColor = '';
+            this.startBtn.classList.remove('btn-pause');
         }
     }
 
@@ -282,8 +279,7 @@ class PomodoroTimer {
         
         if (this.startBtn) {
             this.startBtn.textContent = 'Start';
-            this.startBtn.style.backgroundColor = '';
-            this.startBtn.style.borderColor = '';
+            this.startBtn.classList.remove('btn-pause');
         }
 
         if (this.currentPhase === 'work') {

--- a/pages/pomodoro.html
+++ b/pages/pomodoro.html
@@ -106,8 +106,8 @@
         }
 
         .focus-stat-card {
-            background: var(--shadow-color);
-            border: 1px solid hsla(var(--primary-color-hsl), 0.2);
+            background: var(--primary-dim);
+            border: 1px solid var(--primary-border);
             border-radius: 16px;
             padding: 20px;
             text-align: center;
@@ -115,8 +115,10 @@
         }
 
         .focus-stat-card:hover {
-            background: var(--shadow-color);
+            background: var(--primary-dim);
+            border-color: var(--primary-color);
             transform: translateY(-2px);
+            box-shadow: 0 4px 16px rgba(0, 157, 255, 0.2);
         }
 
         .focus-stat-card .focus-icon {
@@ -159,7 +161,7 @@
         }
 
         .streaks-card h2 i {
-            color: #ffa500;
+            color: var(--streak-color);
             font-size: 1.3rem;
         }
 
@@ -174,7 +176,7 @@
         }
 
         .streak-hint i {
-            color: #ffa500;
+            color: var(--streak-color);
             font-size: 1rem;
         }
 
@@ -185,8 +187,8 @@
         }
 
         .streak-stat-card {
-            background: rgba(255, 165, 0, 0.08);
-            border: 1px solid rgba(255, 165, 0, 0.15);
+            background: var(--streak-dim);
+            border: 1px solid var(--streak-color);
             border-radius: 16px;
             padding: 20px;
             text-align: center;
@@ -194,13 +196,15 @@
         }
 
         .streak-stat-card:hover {
-            background: rgba(255, 165, 0, 0.12);
+            background: var(--streak-dim);
+            border-color: var(--streak-color);
             transform: translateY(-2px);
+            box-shadow: 0 4px 16px rgba(245, 158, 11, 0.2);
         }
 
         .streak-stat-card .streak-icon {
             font-size: 1.8rem;
-            color: #ffa500;
+            color: var(--streak-color);
             margin-bottom: 10px;
         }
 
@@ -215,7 +219,7 @@
         .streak-stat-card .streak-value {
             font-size: 1.8rem;
             font-weight: 700;
-            color: #ffa500;
+            color: var(--streak-color);
         }
 
         /* Progress Bar Section */
@@ -272,8 +276,8 @@
 
         /* Motivation Card */
         .motivation-card {
-            background: linear-gradient(135deg, var(--shadow-color), rgba(var(--primary-color), 0.05));
-            border: 1px solid hsla(var(--primary-color-hsl), 0.2);
+            background: linear-gradient(135deg, var(--card-bg), var(--primary-dim));
+            border: 1px solid var(--primary-border);
             border-radius: 16px;
             padding: 20px;
             display: flex;
@@ -284,10 +288,14 @@
             line-height: 1.6;
         }
 
+        .motivation-card i {
+            color: var(--primary-color);
+        }
+
         /* Day Details */
         .day-details {
-            background: var(--shadow-color);
-            border: 1px solid hsla(var(--primary-color-hsl), 0.2);
+            background: var(--primary-dim);
+            border: 1px solid var(--primary-border);
             border-radius: 16px;
             padding: 24px;
         }
@@ -354,7 +362,15 @@
                 <a href="notes.html" class="nav-link">Notes</a>
                 <a href="roadmap.html" class="nav-link">Roadmap</a>
                 <a href="events.html" class="nav-link">Events</a>
-
+                <div class="timer-nav-controls">
+                    <div class="settings-icon" id="settings-icon" aria-label="Timer settings" title="Settings"></div>
+                    <button id="fullscreenBtn" class="fullscreen-btn" aria-label="Toggle fullscreen" title="Fullscreen">
+                        <svg id="fullscreenIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/>
+                        </svg>
+                        <span></span>
+                    </button>
+                </div>
                 <button
                     class="theme-toggle"
                     aria-label="Toggle dark/light theme"
@@ -368,34 +384,10 @@
 
     <main>
         <!-- SECTION 1: TIMER + CONTROLS -->
-        <div class="container">
-            <!-- Settings and Fullscreen Controls -->
-            <div style="position: fixed; top: 80px; left: 20px; display: flex; gap: 10px; z-index: 1000;">
-                <div class="settings-icon" id="settings-icon" style="cursor: pointer;"></div>
-                
-                <button id="fullscreenBtn" style="
-                    padding: 8px 8px;
-                    background-color: #000000;
-                    color: white;
-                    border: none;
-                    border-radius: 5px;
-                    cursor: pointer;
-                    font-size: 14px;
-                    display: flex;
-                    align-items: center;
-                    gap: 6px;
-                    transition: all 0.3s ease;
-                    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-                    height: 36px;
-                ">
-                    <svg id="fullscreenIcon" style="width: 16px; height: 16px;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/>
-                    </svg>
-                    <span></span>
-                </button>
-            </div>
-
-            <!-- Settings Panel -->
+        <div class="container timer-section">
+            <!-- Timer Card - contains timer and controls -->
+            <div class="timer-section-card">
+            <!-- Settings Panel (opens from navbar gear icon) -->
             <div class="settings-panel" id="settings-panel">
                 <div class="settings-grid">
                     <div class="settings-group">
@@ -415,7 +407,7 @@
                         <input type="number" class="settings-input" id="pomodoros-count" value="4" min="1" max="10">
                     </div>
                 </div>
-                <button class="btn" id="apply-settings">Apply Settings</button>
+                <button class="btn btn-secondary" id="apply-settings">Apply Settings</button>
             </div>
 
             <!-- Timer -->
@@ -445,26 +437,24 @@
 
             <!-- Controls -->
             <div class="controls">
-                <button class="btn" id="start">Start</button>
-                <button class="btn" id="skip">Skip Phase</button>
-                <button class="btn" id="reset">Reset</button>
+                <button class="btn btn-primary" id="start">Start</button>
+                <button class="btn btn-secondary" id="skip">Skip Phase</button>
+                <button class="btn btn-secondary" id="reset">Reset</button>
             </div>
-        </div>
+            </div>
 
-        <!-- SECTION 2: STUDY MUSIC -->
-        <div class="container">
+            <!-- Study Music - directly below timer, centered -->
             <div class="music-section">
                 <h2 class="music-title">Study Music</h2>
-                
                 <div class="music-controls">
                     <input type="text" placeholder="Enter YouTube URL" class="music-input" id="youtube-url">
-                    <button class="btn" id="add-youtube">Load Music</button>
+                    <button class="btn btn-secondary" id="add-youtube">Load Music</button>
                 </div>
                 <div class="youtube-container"></div>
             </div>
         </div>
 
-        <!-- SECTION 3: REDESIGNED STATS + CALENDAR -->
+        <!-- SECTION 2: STATS + CALENDAR -->
         <div class="progress-tracking-wrapper">
             <div class="progress-tracking-section">
                 <!-- LEFT COLUMN: Today's Focus + Streaks -->
@@ -632,24 +622,6 @@
         // Fullscreen functionality
         const btn = document.getElementById('fullscreenBtn');
         const icon = document.getElementById('fullscreenIcon');
-
-        btn.addEventListener('mouseover', () => {
-            btn.style.backgroundColor = '#1976D2';
-            btn.style.transform = 'translateY(-2px)';
-        });
-
-        btn.addEventListener('mouseout', () => {
-            btn.style.backgroundColor = '#2196F3';
-            btn.style.transform = 'translateY(0)';
-        });
-
-        btn.addEventListener('mousedown', () => {
-            btn.style.transform = 'translateY(0) scale(0.95)';
-        });
-
-        btn.addEventListener('mouseup', () => {
-            btn.style.transform = 'translateY(-2px) scale(1)';
-        });
 
         function updateButtonText() {
             const isFullscreen = document.fullscreenElement !== null;

--- a/roadmap_assets/css/progress.css
+++ b/roadmap_assets/css/progress.css
@@ -72,7 +72,7 @@
 .tab-btn.active {
     background: var(--shadow-color);
     color: var(--primary-color);
-    border: 1px solid hsla(var(--primary-color-hsl), 0.3);
+    border: 1px solid var(--primary-border);
 }
 
 .tab-btn i {
@@ -138,7 +138,7 @@
 }
 
 .stat-card.highlight .stat-icon {
-    color: #ffbb35;
+    color: var(--streak-color);
 }
 
 .stat-info {
@@ -154,7 +154,7 @@
 }
 
 .stat-card.highlight .stat-value {
-    color: #ffbb35;
+    color: var(--streak-color);
 }
 
 .stat-label {
@@ -202,16 +202,16 @@
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, var(--primary-color), var(--accent-color), #00d4ff);
+    background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
     border-radius: 7px;
     transition: width 0.5s ease;
-    box-shadow: 0 0 12px rgba(0, 184, 255, 0.5);
+    box-shadow: 0 0 12px rgba(0, 157, 255, 0.4);
 }
 
 /* Motivation Card */
 .motivation-card {
-    background: linear-gradient(135deg, var(--shadow-color), rgba(var(--primary-color), 0.05));
-    border: 1px solid hsla(var(--primary-color-hsl), 0.3);
+    background: linear-gradient(135deg, var(--card-bg), var(--primary-dim));
+    border: 1px solid var(--primary-border);
     border-radius: 12px;
     padding: 20px;
     display: flex;
@@ -253,8 +253,8 @@
 }
 
 .month-nav {
-    background: var(--shadow-color);
-    border: 1px solid hsla(var(--primary-color-hsl), 0.3);
+    background: var(--primary-dim);
+    border: 1px solid var(--primary-border);
     color: var(--primary-color);
     width: 44px;
     height: 44px;
@@ -265,7 +265,8 @@
 }
 
 .month-nav:hover {
-    background: var(--shadow-color);
+    background: var(--primary-color);
+    color: var(--text-light);
     border-color: var(--primary-color);
     transform: scale(1.05);
 }
@@ -337,8 +338,9 @@
 }
 
 .calendar-day.today {
-    border-color: #ffbb35 !important;
-    box-shadow: 0 0 0 2px rgba(255, 187, 53, 0.3);
+    border-color: var(--primary-color) !important;
+    background: var(--primary-dim) !important;
+    box-shadow: 0 0 0 2px var(--primary-border);
 }
 
 .calendar-legend {
@@ -360,11 +362,16 @@
     height: 18px;
     border-radius: 4px;
 }
+.legend-box.intensity-0 { background: var(--bg-darker); }
+.legend-box.intensity-1 { background: rgba(0, 157, 255, 0.2); }
+.legend-box.intensity-2 { background: rgba(0, 157, 255, 0.4); }
+.legend-box.intensity-3 { background: rgba(0, 157, 255, 0.6); }
+.legend-box.intensity-4 { background: rgba(0, 157, 255, 0.8); }
 
 /* Day Details */
 .day-details {
-    background: var(--shadow-color);
-    border: 1px solid hsla(var(--primary-color-hsl), 0.3);
+    background: var(--primary-dim);
+    border: 1px solid var(--primary-border);
     border-radius: 16px;
     padding: 24px;
     margin-bottom: 32px;
@@ -448,40 +455,46 @@
 }
 
 .mgmt-btn.export {
-    background: rgba(37, 211, 102, 0.1);
-    border-color: rgba(37, 211, 102, 0.3);
-    color: #25D366;
+    background: var(--success-dim);
+    border-color: var(--success-color);
+    color: var(--success-color);
 }
 
 .mgmt-btn.export:hover {
-    background: rgba(37, 211, 102, 0.2);
-    border-color: #25D366;
+    background: var(--success-color);
+    color: var(--text-light);
+    border-color: var(--success-color);
     transform: translateY(-2px);
+    box-shadow: 0 4px 14px rgba(34, 197, 94, 0.35);
 }
 
 .mgmt-btn.import {
-    background: var(--shadow-color);
-    border-color: hsla(var(--primary-color-hsl), 0.3);
+    background: var(--primary-dim);
+    border-color: var(--primary-border);
     color: var(--primary-color);
     cursor: pointer;
 }
 
 .mgmt-btn.import:hover {
-    background: var(--shadow-color);
+    background: var(--primary-color);
+    color: var(--text-light);
     border-color: var(--primary-color);
     transform: translateY(-2px);
+    box-shadow: 0 4px 14px rgba(0, 157, 255, 0.35);
 }
 
 .mgmt-btn.clear {
-    background: rgba(255, 68, 68, 0.1);
-    border-color: rgba(255, 68, 68, 0.3);
-    color: #ff4444;
+    background: var(--danger-dim);
+    border-color: var(--danger-color);
+    color: var(--danger-color);
 }
 
 .mgmt-btn.clear:hover {
-    background: rgba(255, 68, 68, 0.2);
-    border-color: #ff4444;
+    background: var(--danger-color);
+    color: var(--text-light);
+    border-color: var(--danger-color);
     transform: translateY(-2px);
+    box-shadow: 0 4px 14px rgba(239, 68, 68, 0.35);
 }
 
 .data-notice {
@@ -489,8 +502,8 @@
     align-items: flex-start;
     gap: 12px;
     padding: 16px;
-    background: var(--shadow-color);
-    border: 1px solid hsla(var(--primary-color-hsl), 0.3);
+    background: var(--primary-dim);
+    border: 1px solid var(--primary-border);
     border-radius: 10px;
     color: var(--text-gray);
     font-size: 0.875rem;


### PR DESCRIPTION
##Pull Request Summary
Improves the UI/UX of the Study Timer (Pomodoro) page by enhancing theme consistency, layout structure, button styles, and navbar behavior for a more modern and organized user experience.

Fixes  #220


---

## Changes Introduced

- Added card-based layout for timer and study music sections to reduce empty space
- Updated timer design and button styles with theme-based colors and hover effects
- Moved Settings & Fullscreen controls into navbar and made navbar sticky
- Applied global theme variables across stats, calendar, and motivation cards for consistency
- Improved responsive design and button state handling (pause styling)


## Screenshots / Demo (for UI changes)
##Before
<img width="742" height="865" alt="studytimer-1" src="https://github.com/user-attachments/assets/a2f6fcef-4c60-4617-b66b-92a880a80d63" />

##After
<img width="1507" height="974" alt="studytimer-2" src="https://github.com/user-attachments/assets/1a0f790c-0293-4c08-8557-31ed8d96fe07" />


## Checklist
Please ensure the following before requesting review:
- [x] Code follows project conventions and best practices.  
- [x] Feature or fix works correctly on both mobile and desktop.  
- [x] No new console errors or accessibility regressions.  
- [x] Documentation updated if applicable.  
- [x] Visuals attached for UI-related updates.  

---

## Additional Notes
All styles use CSS variables to support light/dark theme automatically. Changes are fully responsive and maintain accessibility support.

