### PR TITLE
Add sharing options and PDF preview to notes section

### DIFF
--- a/assets/css/notes.css
+++ b/assets/css/notes.css
@@ -876,6 +876,7 @@ iframe {
 .note-share {
   display: inline-flex;
   position: relative;
+  z-index: 60;
 }
 
 .note-share-menu {
@@ -883,16 +884,23 @@ iframe {
   right: 0;
   top: calc(100% + 8px);
   min-width: 190px;
+  max-height: min(260px, calc(100vh - 2rem));
+  overflow-y: auto;
   padding: 0.5rem;
   background: var(--card-bg);
   border: 1px solid var(--border-color);
   border-radius: 8px;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
-  z-index: 40;
+  z-index: 70;
 }
 
 .note-share-menu[hidden] {
   display: none;
+}
+
+.note-share-menu.open-above {
+  top: auto;
+  bottom: calc(100% + 8px);
 }
 
 .note-share-option {
@@ -949,14 +957,6 @@ iframe {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
-}
-
-.material-card.share-menu-open .pdf-hover-preview {
-  height: 0;
-  margin: 0;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(-6px);
 }
 
 .pdf-preview-heading {

--- a/assets/css/notes.css
+++ b/assets/css/notes.css
@@ -823,3 +823,211 @@ iframe {
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   }
 }
+
+/* Note sharing and hover preview */
+.card::before {
+  pointer-events: none;
+}
+
+.material-card {
+  overflow: visible;
+}
+
+.material-card .card-actions {
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  position: relative;
+  z-index: 10;
+}
+
+.copy-link-btn,
+.share-note-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: transparent;
+  color: var(--primary-color);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 2px solid var(--primary-color);
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 500;
+  min-width: 120px;
+  transition: all var(--transition-speed) ease;
+}
+
+.copy-link-btn:hover,
+.share-note-btn:hover,
+.share-note-btn[aria-expanded="true"] {
+  background: var(--primary-color);
+  color: var(--text-light);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 157, 255, 0.3);
+}
+
+.copy-link-btn:active,
+.share-note-btn:active {
+  transform: translateY(0);
+}
+
+.note-share {
+  display: inline-flex;
+  position: relative;
+}
+
+.note-share-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  min-width: 190px;
+  padding: 0.5rem;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  z-index: 40;
+}
+
+.note-share-menu[hidden] {
+  display: none;
+}
+
+.note-share-option {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  color: var(--text-light);
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  text-align: left;
+}
+
+.note-share-option:hover,
+.note-share-option:focus-visible {
+  background: var(--primary-dim);
+  color: var(--primary-color);
+}
+
+.note-share-option i {
+  width: 18px;
+  text-align: center;
+}
+
+.pdf-hover-preview {
+  width: 100%;
+  height: 0;
+  margin: 0;
+  background: var(--card-bg);
+  border: 1px solid var(--primary-border);
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px rgba(0, 157, 255, 0.04);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-6px);
+  transition:
+    height var(--transition-speed) ease,
+    margin var(--transition-speed) ease,
+    opacity var(--transition-speed) ease,
+    transform var(--transition-speed) ease,
+    visibility var(--transition-speed) ease;
+  overflow: hidden;
+  pointer-events: auto;
+}
+
+.material-card.has-pdf-preview:hover .pdf-hover-preview,
+.material-card.has-pdf-preview:focus-within .pdf-hover-preview {
+  height: 260px;
+  margin: 0 0 1rem;
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.material-card.share-menu-open .pdf-hover-preview {
+  height: 0;
+  margin: 0;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-6px);
+}
+
+.pdf-preview-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.8rem;
+  color: var(--text-light);
+  background: var(--bg-darker);
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.pdf-preview-frame {
+  width: 100%;
+  height: calc(100% - 42px);
+  border: 0;
+  background: var(--input-bg);
+}
+
+.note-toast {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 10000;
+  max-width: min(320px, calc(100vw - 2rem));
+  padding: 0.9rem 1.1rem;
+  color: var(--text-light);
+  background: var(--card-bg);
+  border: 1px solid var(--primary-color);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s ease;
+}
+
+.note-toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (min-width: 769px) {
+  .material-card .card-actions {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 768px) {
+  .pdf-hover-preview {
+    display: none;
+  }
+
+  .copy-link-btn,
+  .share-note-btn,
+  .note-share {
+    width: 100%;
+  }
+
+  .note-share-menu {
+    left: 0;
+    right: 0;
+    width: 100%;
+  }
+
+  .note-toast {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+  }
+}

--- a/assets/js/pages/notes/notes-main.js
+++ b/assets/js/pages/notes/notes-main.js
@@ -78,37 +78,27 @@ function displayMaterials(semesterId, branchId, subjectId) {
     content.innerHTML = '';
     content.className = 'materials-container'; // Remove grid class to prevent cards from being clickable
 
-    // Detect if mobile device
-    const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-
     subject.materials.forEach(material => {
         const card = document.createElement('div');
         card.className = 'card material-card'; // Add specific class for material cards
 
         // Get the material data
         const filePath = material.path || '';
-
-        // Get absolute path for PDF files
-        let absoluteFilePath = filePath;
-        if (filePath.startsWith('/')) {
-            absoluteFilePath = window.location.origin + filePath;
-        }
+        const fileUrl = getMaterialFileUrl(filePath);
 
         const uploadDate = material.uploadDate ? new Date(material.uploadDate).toLocaleDateString() : 'Unknown';
-
-        // Create a safe download filename
-        const safeFileName = material.title.replace(/[^a-z0-9]/gi, '_').toLowerCase() + '.pdf';
 
         // Get thumbnail URL if available
         const thumbnailUrl = material.thumbnailUrl || '';
         const hasThumbnail = thumbnailUrl && thumbnailUrl.length > 0;
+        const contextText = `${semester.name} | ${branch.name} | ${subject.name}`;
 
         // Create the card content with thumbnail if available
         let thumbnailHTML = '';
         if (hasThumbnail) {
             thumbnailHTML = `
                 <div class="thumbnail-container">
-                    <img src="${thumbnailUrl}" alt="PDF Preview" class="material-thumbnail" 
+                    <img src="${sanitizeHTML(thumbnailUrl)}" alt="PDF Preview" class="material-thumbnail"
                          onerror="this.style.display='none'">
                 </div>
             `;
@@ -118,19 +108,14 @@ function displayMaterials(semesterId, branchId, subjectId) {
         card.innerHTML = `
             ${thumbnailHTML}
             <div class="card-header">
-                <h3>${material.title}</h3>
-                <p>${material.description}</p>
-                <p><span class="meta-label">Size:</span> ${material.size || 'Unknown'}</p>
+                <h3>${sanitizeHTML(material.title || 'Untitled notes')}</h3>
+                <p>${sanitizeHTML(material.description || 'No description available.')}</p>
+                <p><span class="meta-label">Size:</span> ${sanitizeHTML(material.size || 'Unknown')}</p>
                 <p><span class="meta-label">Uploaded:</span> ${uploadDate}</p>
             </div>
+            ${createPdfPreviewHTML(material, fileUrl)}
             <div class="card-actions">
-                <a href="${absoluteFilePath}" 
-                   target="_blank" class="view-btn">
-                    View PDF
-                </a>
-                <a href="${absoluteFilePath}" download="${safeFileName}" class="download-btn">
-                    Download
-                </a>
+                ${createNoteActionsHTML(material, contextText)}
             </div>
         `;
 
@@ -138,6 +123,7 @@ function displayMaterials(semesterId, branchId, subjectId) {
         card.style.cursor = 'default';
 
         content.appendChild(card);
+        setupMaterialCardInteractions(card);
     });
 
     navigationState.semester = semesterId;

--- a/assets/js/pages/notes/notes-search.js
+++ b/assets/js/pages/notes/notes-search.js
@@ -16,14 +16,14 @@ function handleSearch(event) {
 
 function searchNotes(term) {
     const results = [];
-    
+
     window.notesData.semesters.forEach(semester => {
         semester.branches.forEach(branch => {
             branch.subjects.forEach(subject => {
                 subject.materials.forEach(material => {
                     if (material.title.toLowerCase().includes(term) ||
                         material.description.toLowerCase().includes(term) ||
-                        (material.keywords && material.keywords.some(keyword => 
+                        (material.keywords && material.keywords.some(keyword =>
                             keyword.toLowerCase().includes(term)
                         ))) {
                         results.push({
@@ -39,7 +39,7 @@ function searchNotes(term) {
             });
         });
     });
-    
+
     return results;
 }
 
@@ -52,60 +52,43 @@ function displaySearchResults(results) {
         content.innerHTML = '<div class="no-results">No results found</div>';
         return;
     }
-    
+
     // Add results count
     const resultCount = document.createElement('div');
     resultCount.className = 'result-count';
     resultCount.textContent = `Found ${results.length} results`;
     content.appendChild(resultCount);
 
-    // Detect if mobile device
-    const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-
     results.forEach(result => {
         const card = document.createElement('div');
         card.className = 'card search-result material-card';
-        
+
         // Format the date if it exists
-        const uploadDate = result.material.uploadDate ? 
+        const uploadDate = result.material.uploadDate ?
             new Date(result.material.uploadDate).toLocaleDateString() : 'N/A';
-        
-        // Use path directly for the file path
-        const filePath = result.material.path || '';
-        
-        // Get absolute path for PDF files
-        let absoluteFilePath = filePath;
-        if (filePath.startsWith('/')) {
-            absoluteFilePath = window.location.origin + filePath;
-        }
-        
-        // Create a safe download filename
-        const safeFileName = result.material.title.replace(/[^a-z0-9]/gi, '_').toLowerCase() + '.pdf';
-        
+        const fileUrl = getMaterialFileUrl(result.material.path || '');
+        const contextText = `${result.semester} | ${result.branch} | ${result.subject}`;
+
         card.innerHTML = `
             <div class="card-content">
-                <h3>${result.material.title}</h3>
-                <p class="description">${result.material.description}</p>
+                <h3>${sanitizeHTML(result.material.title || 'Untitled notes')}</h3>
+                <p class="description">${sanitizeHTML(result.material.description || 'No description available.')}</p>
                 <div class="metadata">
-                    <span class="material-path">${result.semester} | ${result.branch} | ${result.subject}</span>
-                    <span class="file-info">${result.material.type.toUpperCase()} • ${result.material.size || 'Unknown'} • Upload: ${uploadDate}</span>
+                    <span class="material-path">${sanitizeHTML(contextText)}</span>
+                    <span class="file-info">${sanitizeHTML((result.material.type || 'pdf').toUpperCase())} &bull; ${sanitizeHTML(result.material.size || 'Unknown')} &bull; Upload: ${uploadDate}</span>
                 </div>
             </div>
+            ${createPdfPreviewHTML(result.material, fileUrl)}
             <div class="card-actions">
-                <a href="${absoluteFilePath}" 
-                   target="_blank" class="view-btn">
-                    View PDF
-                </a>
-                <a href="${absoluteFilePath}" download="${safeFileName}" class="download-btn">
-                    Download
-                </a>
+                ${createNoteActionsHTML(result.material, contextText)}
             </div>
         `;
-        
+
         // Remove cursor pointer style
         card.style.cursor = 'default';
-        
+
         content.appendChild(card);
+        setupMaterialCardInteractions(card);
     });
 }
 
@@ -117,4 +100,3 @@ function debounce(func, delay) {
         timeout = setTimeout(() => func.apply(this, args), delay);
     };
 }
-

--- a/assets/js/pages/notes/notes-utils.js
+++ b/assets/js/pages/notes/notes-utils.js
@@ -205,7 +205,10 @@ function setupMaterialCardInteractions(card) {
         closeAllNoteShareMenus();
         shareMenu.hidden = isOpen;
         shareButton.setAttribute('aria-expanded', String(!isOpen));
-        card.classList.toggle('share-menu-open', !isOpen);
+
+        if (!isOpen) {
+            positionNoteShareMenu(shareMenu);
+        }
     });
 
     shareMenu?.addEventListener('click', (event) => {
@@ -250,14 +253,24 @@ function ensureNoteShareGlobalListeners() {
 function closeAllNoteShareMenus() {
     document.querySelectorAll('.note-share-menu').forEach(menu => {
         menu.hidden = true;
+        menu.classList.remove('open-above');
     });
 
     document.querySelectorAll('.share-note-btn[aria-expanded="true"]').forEach(button => {
         button.setAttribute('aria-expanded', 'false');
     });
+}
 
-    document.querySelectorAll('.material-card.share-menu-open').forEach(card => {
-        card.classList.remove('share-menu-open');
+function positionNoteShareMenu(menu) {
+    menu.classList.remove('open-above');
+
+    requestAnimationFrame(() => {
+        const menuRect = menu.getBoundingClientRect();
+        const bottomSpace = window.innerHeight - menuRect.bottom;
+
+        if (bottomSpace < 16) {
+            menu.classList.add('open-above');
+        }
     });
 }
 

--- a/assets/js/pages/notes/notes-utils.js
+++ b/assets/js/pages/notes/notes-utils.js
@@ -34,3 +34,270 @@ function formatFileSize(bytes) {
     return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
 }
 
+function getMaterialFileUrl(filePath) {
+    if (!filePath) return '#';
+    if (/^https?:\/\//i.test(filePath)) return filePath;
+    if (filePath.startsWith('/')) return window.location.origin + filePath;
+    return filePath;
+}
+
+function getAbsoluteUrl(url) {
+    try {
+        return new URL(url, window.location.href).href;
+    } catch (error) {
+        return window.location.href;
+    }
+}
+
+function getFileExtension(filePath, fallbackType) {
+    const cleanPath = (filePath || '').split('?')[0].split('#')[0];
+    const extensionMatch = cleanPath.match(/\.([a-z0-9]+)$/i);
+    return (extensionMatch ? extensionMatch[1] : fallbackType || 'pdf').toLowerCase();
+}
+
+function getSafeDownloadFileName(material) {
+    const extension = getFileExtension(material.path, material.type);
+    const safeTitle = (material.title || 'college-daddy-notes')
+        .replace(/[^a-z0-9]/gi, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_|_$/g, '')
+        .toLowerCase();
+
+    return `${safeTitle || 'college-daddy-notes'}.${extension}`;
+}
+
+function getShareText(material, contextText) {
+    const title = material.title || 'College Daddy notes';
+    const description = material.description ? ` - ${material.description}` : '';
+    const context = contextText ? `\n${contextText}` : '';
+    return `${title}${description}${context}`;
+}
+
+function getPdfPreviewUrl(fileUrl) {
+    const absoluteUrl = getAbsoluteUrl(fileUrl);
+    return absoluteUrl.includes('#')
+        ? absoluteUrl
+        : `${absoluteUrl}#toolbar=0&navpanes=0&view=FitH`;
+}
+
+function createPdfPreviewHTML(material, fileUrl) {
+    if (getFileExtension(material.path, material.type) !== 'pdf') {
+        return '';
+    }
+
+    const previewUrl = sanitizeHTML(getPdfPreviewUrl(fileUrl));
+    const title = sanitizeHTML(material.title || 'PDF notes');
+
+    return `
+        <div class="pdf-hover-preview" aria-label="PDF preview for ${title}">
+            <div class="pdf-preview-heading">
+                <span>Quick preview</span>
+            </div>
+            <iframe
+                class="pdf-preview-frame"
+                title="Preview of ${title}"
+                loading="lazy"
+                data-src="${previewUrl}">
+            </iframe>
+        </div>
+    `;
+}
+
+function createNoteActionsHTML(material, contextText = '') {
+    const fileUrl = getMaterialFileUrl(material.path || '');
+    const shareUrl = getAbsoluteUrl(fileUrl);
+    const shareText = getShareText(material, contextText);
+    const title = material.title || 'College Daddy notes';
+    const safeFileName = getSafeDownloadFileName(material);
+    const encodedTextWithUrl = encodeURIComponent(`${shareText}\n${shareUrl}`);
+    const encodedShareUrl = encodeURIComponent(shareUrl);
+    const encodedTitle = encodeURIComponent(title);
+    const encodedEmailBody = encodeURIComponent(`${shareText}\n\n${shareUrl}`);
+
+    return `
+        <a href="${sanitizeHTML(fileUrl)}"
+           target="_blank"
+           rel="noopener noreferrer"
+           class="view-btn">
+            View PDF
+        </a>
+        <a href="${sanitizeHTML(fileUrl)}"
+           download="${sanitizeHTML(safeFileName)}"
+           class="download-btn">
+            Download
+        </a>
+        <button
+            type="button"
+            class="copy-link-btn"
+            data-note-url="${sanitizeHTML(shareUrl)}"
+            aria-label="Copy link for ${sanitizeHTML(title)}">
+            Copy Link
+        </button>
+        <div
+            class="note-share"
+            data-share-title="${sanitizeHTML(title)}"
+            data-share-text="${sanitizeHTML(shareText)}"
+            data-share-url="${sanitizeHTML(shareUrl)}">
+            <button
+                type="button"
+                class="share-note-btn"
+                aria-expanded="false"
+                aria-label="Share ${sanitizeHTML(title)}">
+                Share
+            </button>
+            <div class="note-share-menu" hidden>
+                <button type="button" class="note-share-option native-share-option">
+                    Device Share
+                </button>
+                <a class="note-share-option"
+                   href="https://wa.me/?text=${encodedTextWithUrl}"
+                   target="_blank"
+                   rel="noopener noreferrer">
+                    WhatsApp
+                </a>
+                <a class="note-share-option"
+                   href="https://t.me/share/url?url=${encodedShareUrl}&text=${encodeURIComponent(shareText)}"
+                   target="_blank"
+                   rel="noopener noreferrer">
+                    Telegram
+                </a>
+                <a class="note-share-option"
+                   href="mailto:?subject=${encodedTitle}&body=${encodedEmailBody}">
+                    Email
+                </a>
+            </div>
+        </div>
+    `;
+}
+
+function setupMaterialCardInteractions(card) {
+    const previewFrame = card.querySelector('.pdf-preview-frame');
+    if (previewFrame) {
+        const loadPreview = () => {
+            if (!previewFrame.src) {
+                previewFrame.src = previewFrame.dataset.src;
+            }
+        };
+
+        card.classList.add('has-pdf-preview');
+        card.addEventListener('mouseenter', loadPreview, { once: true });
+        card.addEventListener('focusin', loadPreview, { once: true });
+    }
+
+    const copyButton = card.querySelector('.copy-link-btn');
+    copyButton?.addEventListener('click', async (event) => {
+        event.stopPropagation();
+        await copyNoteLink(copyButton.dataset.noteUrl);
+    });
+
+    const share = card.querySelector('.note-share');
+    const shareButton = share?.querySelector('.share-note-btn');
+    const shareMenu = share?.querySelector('.note-share-menu');
+    const nativeShareButton = share?.querySelector('.native-share-option');
+
+    if (nativeShareButton && !navigator.share) {
+        nativeShareButton.hidden = true;
+    }
+
+    shareButton?.addEventListener('click', (event) => {
+        event.stopPropagation();
+        const isOpen = !shareMenu.hidden;
+        closeAllNoteShareMenus();
+        shareMenu.hidden = isOpen;
+        shareButton.setAttribute('aria-expanded', String(!isOpen));
+        card.classList.toggle('share-menu-open', !isOpen);
+    });
+
+    shareMenu?.addEventListener('click', (event) => {
+        event.stopPropagation();
+    });
+
+    nativeShareButton?.addEventListener('click', async () => {
+        if (!navigator.share) return;
+
+        try {
+            await navigator.share({
+                title: share.dataset.shareTitle,
+                text: share.dataset.shareText,
+                url: share.dataset.shareUrl
+            });
+            showNoteToast('Shared successfully!');
+            closeAllNoteShareMenus();
+        } catch (error) {
+            if (error.name !== 'AbortError') {
+                showNoteToast('Unable to share right now.');
+            }
+        }
+    });
+
+    ensureNoteShareGlobalListeners();
+}
+
+let noteShareGlobalListenersReady = false;
+
+function ensureNoteShareGlobalListeners() {
+    if (noteShareGlobalListenersReady) return;
+    noteShareGlobalListenersReady = true;
+
+    document.addEventListener('click', closeAllNoteShareMenus);
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            closeAllNoteShareMenus();
+        }
+    });
+}
+
+function closeAllNoteShareMenus() {
+    document.querySelectorAll('.note-share-menu').forEach(menu => {
+        menu.hidden = true;
+    });
+
+    document.querySelectorAll('.share-note-btn[aria-expanded="true"]').forEach(button => {
+        button.setAttribute('aria-expanded', 'false');
+    });
+
+    document.querySelectorAll('.material-card.share-menu-open').forEach(card => {
+        card.classList.remove('share-menu-open');
+    });
+}
+
+async function copyNoteLink(url) {
+    try {
+        await navigator.clipboard.writeText(url);
+        showNoteToast('Link copied to clipboard!');
+    } catch (error) {
+        const textArea = document.createElement('textarea');
+        textArea.value = url;
+        textArea.setAttribute('readonly', '');
+        textArea.style.position = 'fixed';
+        textArea.style.opacity = '0';
+        document.body.appendChild(textArea);
+        textArea.select();
+
+        try {
+            document.execCommand('copy');
+            showNoteToast('Link copied to clipboard!');
+        } catch (copyError) {
+            showNoteToast('Could not copy the link.');
+        }
+
+        document.body.removeChild(textArea);
+    }
+}
+
+function showNoteToast(message) {
+    const existingToast = document.querySelector('.note-toast');
+    if (existingToast) existingToast.remove();
+
+    const toast = document.createElement('div');
+    toast.className = 'note-toast';
+    toast.textContent = message;
+    document.body.appendChild(toast);
+
+    setTimeout(() => toast.classList.add('show'), 10);
+    setTimeout(() => {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 250);
+    }, 2500);
+}
+


### PR DESCRIPTION
### 🚀 Overview
This PR enhances the Notes section by adding sharing functionality and improving user experience with quick preview support.

---

## Changes Introduced
- Added reusable note action helpers for View PDF, Download, Copy Link, and Share.
- Added native browser share support with WhatsApp, Telegram, and Email fallback options.
- Added lazy-loaded inline PDF preview on note card hover.
- Applied the same note actions to both subject material cards and search result cards.

---

## Screenshots / Demo (for UI changes)
Added screenshots showing:

- Share dropdown options

<img width="1920" height="1080" alt="Screenshot (239)" src="https://github.com/user-attachments/assets/9b706d00-33b5-4dfc-8537-f3128974376a" />


- inline PDF preview for note cards

<img width="1920" height="1080" alt="Screenshot (238)" src="https://github.com/user-attachments/assets/0167e7dc-b970-43b1-9156-f5547bc48162" />




---

## Checklist
- [x] Code follows project conventions and best practices.
- [x] Feature or fix works correctly on desktop.
- [x] Mobile layout remains usable, with hover preview disabled on small screens.
- [x] No new console errors observed during local testing.
- [x] Documentation updated if applicable.
- [x] Visuals attached for UI-related updates.

---

## Additional Notes
The PDF preview is lazy-loaded only when a user hovers or focuses a card, so all previews are not loaded upfront. The note action rendering is reusable to keep behavior consistent between normal note cards and search results.

### 📌 Issue Reference
Closes #245