### PR TITLE
Integrate Project Architect flowchart workspace into College Daddy

### DIFF
--- a/assets/css/project-architect.css
+++ b/assets/css/project-architect.css
@@ -262,7 +262,7 @@
 }
 
 .arrow-head {
-  fill: #38bdf8;
+  fill: context-stroke;
 }
 
 .edge-path {
@@ -273,7 +273,8 @@
 }
 
 .edge-path.selected {
-  stroke: #f59e0b;
+  stroke-width: 4;
+  filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.35));
 }
 
 .node-group {
@@ -287,11 +288,13 @@
 }
 
 .node-group.selected .node-shape {
-  stroke: #38bdf8;
+  stroke-width: 3;
+  filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.3));
 }
 
 .node-group.connect-source .node-shape {
-  stroke: #f59e0b;
+  stroke-width: 3;
+  filter: drop-shadow(0 0 10px rgba(245, 158, 11, 0.45));
 }
 
 .node-label {
@@ -330,6 +333,22 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.8rem;
+}
+
+.color-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+input[type="color"] {
+  min-height: 52px;
+  padding: 0.35rem;
+  cursor: pointer;
+}
+
+input[type="color"]:disabled {
+  cursor: not-allowed;
 }
 
 .inspector-state {
@@ -388,6 +407,10 @@
   }
 
   .size-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .color-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/assets/css/project-architect.css
+++ b/assets/css/project-architect.css
@@ -1,0 +1,393 @@
+.architect-page {
+  padding: 2rem 0 3rem;
+}
+
+.architect-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.9fr);
+  gap: 1.5rem;
+  align-items: stretch;
+  margin-bottom: 1.5rem;
+}
+
+.hero-copy,
+.hero-card,
+.architect-panel,
+.workspace-toolbar,
+.canvas-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 55%),
+    var(--card-bg);
+}
+
+.hero-copy {
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 3vw, 2.6rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-copy::after {
+  content: "";
+  position: absolute;
+  inset: auto -10% -35% auto;
+  width: 260px;
+  height: 260px;
+  background: radial-gradient(circle, var(--primary-dim) 0%, transparent 72%);
+  pointer-events: none;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  background: var(--primary-dim);
+  border: 1px solid var(--primary-border);
+  color: var(--primary-color);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero-copy h1 {
+  margin-top: 1rem;
+  font-size: clamp(2.4rem, 4vw, 4rem);
+}
+
+.hero-copy p {
+  margin-top: 0.9rem;
+  max-width: 60ch;
+  font-size: 1.05rem;
+}
+
+.hero-points {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1.2rem;
+}
+
+.hero-points span,
+.mode-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.55rem 0.8rem;
+  color: var(--text-gray);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.hero-card,
+.architect-panel,
+.workspace-toolbar,
+.canvas-card {
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+}
+
+.hero-card {
+  padding: 1.5rem;
+}
+
+.hero-card h2 {
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+}
+
+.hero-card ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-gray);
+}
+
+.hero-card li + li {
+  margin-top: 0.6rem;
+}
+
+.architect-shell {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 280px;
+  gap: 1rem;
+  align-items: start;
+}
+
+.architect-panel {
+  padding: 1.2rem;
+  position: sticky;
+  top: 92px;
+}
+
+.panel-heading h2,
+.canvas-meta h2 {
+  font-size: 1.05rem;
+}
+
+.panel-heading p,
+.canvas-meta p {
+  margin-top: 0.35rem;
+  font-size: 0.92rem;
+}
+
+.shape-palette {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+
+.shape-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-light);
+  cursor: grab;
+  transition:
+    transform var(--transition-speed) ease,
+    border-color var(--transition-speed) ease,
+    background-color var(--transition-speed) ease;
+}
+
+.shape-chip:hover,
+.shape-chip:focus-visible {
+  border-color: var(--primary-border);
+  background: var(--primary-dim);
+  transform: translateY(-1px);
+}
+
+.shape-chip:active {
+  cursor: grabbing;
+}
+
+.shape-preview {
+  width: 2.5rem;
+  height: 1.6rem;
+  border: 2px solid currentColor;
+  color: var(--primary-color);
+  flex: 0 0 auto;
+}
+
+.preview-pill {
+  border-radius: 999px;
+}
+
+.preview-rect {
+  border-radius: 0.55rem;
+}
+
+.preview-diamond {
+  width: 1.8rem;
+  height: 1.8rem;
+  transform: rotate(45deg);
+  border-radius: 0.3rem;
+}
+
+.preview-input {
+  clip-path: polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%);
+  background: currentColor;
+  opacity: 0.14;
+}
+
+.starter-actions {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 1.1rem;
+}
+
+.canvas-column {
+  display: grid;
+  gap: 1rem;
+}
+
+.workspace-toolbar {
+  padding: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.toolbar-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.canvas-card {
+  padding: 1rem;
+}
+
+.canvas-meta {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.canvas-stage {
+  position: relative;
+  min-height: 760px;
+  border-radius: 22px;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background:
+    radial-gradient(circle at top left, rgba(20, 184, 166, 0.08), transparent 22%),
+    linear-gradient(180deg, rgba(14, 165, 233, 0.05), transparent 24%),
+    color-mix(in srgb, var(--bg-darker) 92%, #0b1220);
+}
+
+.diagram-canvas {
+  width: 100%;
+  height: 760px;
+  display: block;
+  touch-action: none;
+}
+
+.grid-line {
+  fill: none;
+  stroke: rgba(148, 163, 184, 0.16);
+  stroke-width: 1;
+}
+
+.arrow-head {
+  fill: #38bdf8;
+}
+
+.edge-path {
+  fill: none;
+  stroke: #38bdf8;
+  stroke-width: 2.5;
+  marker-end: url(#arrowhead);
+}
+
+.edge-path.selected {
+  stroke: #f59e0b;
+}
+
+.node-group {
+  cursor: move;
+}
+
+.node-shape {
+  fill: rgba(15, 23, 42, 0.92);
+  stroke: rgba(148, 163, 184, 0.65);
+  stroke-width: 2;
+}
+
+.node-group.selected .node-shape {
+  stroke: #38bdf8;
+}
+
+.node-group.connect-source .node-shape {
+  stroke: #f59e0b;
+}
+
+.node-label {
+  fill: #e7edf7;
+  font-family: "Plus Jakarta Sans", "Segoe UI", sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  user-select: none;
+  pointer-events: none;
+}
+
+[data-theme="light"] .node-shape {
+  fill: rgba(255, 255, 255, 0.96);
+  stroke: rgba(71, 85, 105, 0.45);
+}
+
+[data-theme="light"] .node-label {
+  fill: #0f172a;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: 1rem;
+}
+
+.field span {
+  color: var(--text-gray);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.size-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.inspector-state {
+  margin-top: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-light);
+  font-weight: 600;
+}
+
+.inspector-note {
+  margin-top: 1rem;
+  border-left: 3px solid var(--primary-color);
+  padding-left: 0.9rem;
+  color: var(--text-gray);
+  font-size: 0.94rem;
+}
+
+@media (max-width: 1180px) {
+  .architect-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .architect-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 900px) {
+  .architect-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .canvas-meta,
+  .workspace-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .mode-pill {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .architect-page {
+    padding-top: 1.25rem;
+  }
+
+  .canvas-stage,
+  .diagram-canvas {
+    min-height: 560px;
+    height: 560px;
+  }
+
+  .size-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/components/footer.js
+++ b/assets/js/components/footer.js
@@ -39,6 +39,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <li><a href="${homeHref}">Home</a></li>
           <li><a href="${pagePrefix}cgpa.html">CGPA Calculator</a></li>
           <li><a href="${pagePrefix}notes.html">Notes</a></li>
+          <li><a href="${pagePrefix}project-architect.html">Project Architect</a></li>
           <li><a href="${pagePrefix}roadmap.html">Roadmap</a></li>
         </ul>
       </section>

--- a/assets/js/pages/index.js
+++ b/assets/js/pages/index.js
@@ -37,7 +37,12 @@ function initTypingAnimation() {
     return;
   }
 
-  const words = ["CGPA Calculator", "Study Timer", "Career Roadmaps"];
+  const words = [
+    "CGPA Calculator",
+    "Study Timer",
+    "Career Roadmaps",
+    "Project Architect",
+  ];
   let wordIndex = 0;
   let letterIndex = 0;
 

--- a/assets/js/pages/project-architect.js
+++ b/assets/js/pages/project-architect.js
@@ -12,6 +12,12 @@ const DEFAULT_LABELS = {
   decision: "Decision",
   input: "Input / Output",
 };
+const DEFAULT_NODE_COLORS = {
+  fill: "#0f172a",
+  stroke: "#94a3b8",
+  text: "#e7edf7",
+};
+const DEFAULT_EDGE_COLOR = "#38bdf8";
 
 class ProjectArchitect {
   constructor() {
@@ -29,6 +35,9 @@ class ProjectArchitect {
     this.labelInput = document.getElementById("labelInput");
     this.widthInput = document.getElementById("widthInput");
     this.heightInput = document.getElementById("heightInput");
+    this.fillColorInput = document.getElementById("fillColorInput");
+    this.strokeColorInput = document.getElementById("strokeColorInput");
+    this.accentColorInput = document.getElementById("accentColorInput");
     this.selectionSummary = document.getElementById("selectionSummary");
     this.modePill = document.getElementById("modePill");
     this.inspectorNote = document.getElementById("inspectorNote");
@@ -158,6 +167,40 @@ class ProjectArchitect {
       this.render();
       this.updateInspector();
     });
+
+    this.fillColorInput.addEventListener("input", () => {
+      const node = this.getSelectedNode();
+      if (!node) {
+        return;
+      }
+      node.fill = this.fillColorInput.value;
+      this.render();
+    });
+
+    this.strokeColorInput.addEventListener("input", () => {
+      const node = this.getSelectedNode();
+      if (!node) {
+        return;
+      }
+      node.stroke = this.strokeColorInput.value;
+      this.render();
+    });
+
+    this.accentColorInput.addEventListener("input", () => {
+      const node = this.getSelectedNode();
+      if (node) {
+        node.textColor = this.accentColorInput.value;
+        this.render();
+        return;
+      }
+
+      const edge = this.getSelectedEdge();
+      if (!edge) {
+        return;
+      }
+      edge.color = this.accentColorInput.value;
+      this.render();
+    });
   }
 
   addNode(shape, x, y) {
@@ -181,6 +224,9 @@ class ProjectArchitect {
       width: baseSize.width,
       height: baseSize.height,
       label: DEFAULT_LABELS[shape] || "Step",
+      fill: DEFAULT_NODE_COLORS.fill,
+      stroke: DEFAULT_NODE_COLORS.stroke,
+      textColor: DEFAULT_NODE_COLORS.text,
     };
 
     this.nodes.push(node);
@@ -204,6 +250,7 @@ class ProjectArchitect {
       id: `edge-${crypto.randomUUID()}`,
       from,
       to,
+      color: DEFAULT_EDGE_COLOR,
     });
     this.selection = { type: "edge", id: this.edges[this.edges.length - 1].id };
     this.render();
@@ -267,6 +314,9 @@ class ProjectArchitect {
         width: 180,
         height: 80,
         label: "Start",
+        fill: "#132033",
+        stroke: "#60a5fa",
+        textColor: "#e7edf7",
       },
       {
         id: "sample-input",
@@ -276,6 +326,9 @@ class ProjectArchitect {
         width: 210,
         height: 90,
         label: "Collect Inputs",
+        fill: "#10203a",
+        stroke: "#7dd3fc",
+        textColor: "#e7edf7",
       },
       {
         id: "sample-decision",
@@ -285,6 +338,9 @@ class ProjectArchitect {
         width: 180,
         height: 120,
         label: "Criteria Met?",
+        fill: "#1f2336",
+        stroke: "#a78bfa",
+        textColor: "#f8fafc",
       },
       {
         id: "sample-process",
@@ -294,6 +350,9 @@ class ProjectArchitect {
         width: 220,
         height: 100,
         label: "Generate Output",
+        fill: "#18252e",
+        stroke: "#2dd4bf",
+        textColor: "#f8fafc",
       },
       {
         id: "sample-end",
@@ -303,14 +362,17 @@ class ProjectArchitect {
         width: 180,
         height: 80,
         label: "End",
+        fill: "#14253a",
+        stroke: "#38bdf8",
+        textColor: "#f8fafc",
       },
     ];
 
     this.edges = [
-      { id: "edge-1", from: "sample-start", to: "sample-input" },
-      { id: "edge-2", from: "sample-input", to: "sample-decision" },
-      { id: "edge-3", from: "sample-decision", to: "sample-process" },
-      { id: "edge-4", from: "sample-process", to: "sample-end" },
+      { id: "edge-1", from: "sample-start", to: "sample-input", color: "#38bdf8" },
+      { id: "edge-2", from: "sample-input", to: "sample-decision", color: "#38bdf8" },
+      { id: "edge-3", from: "sample-decision", to: "sample-process", color: "#38bdf8" },
+      { id: "edge-4", from: "sample-process", to: "sample-end", color: "#38bdf8" },
     ];
 
     this.selection = { type: "node", id: "sample-input" };
@@ -350,6 +412,13 @@ class ProjectArchitect {
       return null;
     }
     return this.nodes.find((node) => node.id === this.selection.id) || null;
+  }
+
+  getSelectedEdge() {
+    if (!this.selection || this.selection.type !== "edge") {
+      return null;
+    }
+    return this.edges.find((edge) => edge.id === this.selection.id) || null;
   }
 
   handleNodeInteraction(node, event) {
@@ -424,12 +493,15 @@ class ProjectArchitect {
 
       const shape = this.createNodeShape(node);
       shape.classList.add("node-shape");
+      shape.style.fill = node.fill || DEFAULT_NODE_COLORS.fill;
+      shape.style.stroke = node.stroke || DEFAULT_NODE_COLORS.stroke;
       group.appendChild(shape);
 
       const text = document.createElementNS(SVG_NS, "text");
       text.setAttribute("x", String(node.x));
       text.setAttribute("y", String(node.y));
       text.setAttribute("class", "node-label");
+      text.style.fill = node.textColor || DEFAULT_NODE_COLORS.text;
       text.textContent = node.label;
       group.appendChild(text);
 
@@ -514,6 +586,7 @@ class ProjectArchitect {
       path.setAttribute("class", "edge-path");
       path.dataset.edgeId = edge.id;
       path.setAttribute("d", this.buildConnectorPath(fromNode, toNode));
+      path.style.stroke = edge.color || DEFAULT_EDGE_COLOR;
 
       if (this.selection?.type === "edge" && this.selection.id === edge.id) {
         path.classList.add("selected");
@@ -557,29 +630,48 @@ class ProjectArchitect {
 
   updateInspector() {
     const node = this.getSelectedNode();
+    const edge = this.getSelectedEdge();
     const hasNode = Boolean(node);
+    const hasEdge = Boolean(edge);
 
     this.labelInput.disabled = !hasNode;
     this.widthInput.disabled = !hasNode;
     this.heightInput.disabled = !hasNode;
+    this.fillColorInput.disabled = !hasNode;
+    this.strokeColorInput.disabled = !hasNode;
+    this.accentColorInput.disabled = !hasNode && !hasEdge;
 
     if (node) {
       this.selectionSummary.textContent = `${this.titleCase(node.shape)} node selected`;
       this.labelInput.value = node.label;
       this.widthInput.value = String(node.width);
       this.heightInput.value = String(node.height);
+      this.fillColorInput.value = this.normalizeColor(
+        node.fill || DEFAULT_NODE_COLORS.fill,
+      );
+      this.strokeColorInput.value = this.normalizeColor(
+        node.stroke || DEFAULT_NODE_COLORS.stroke,
+      );
+      this.accentColorInput.value = this.normalizeColor(
+        node.textColor || DEFAULT_NODE_COLORS.text,
+      );
       this.inspectorNote.textContent =
-        "Resize in clean 20px steps to keep the flowchart aligned on the academic grid.";
+        "Resize in clean 20px steps and use the color pickers to match your report theme.";
       return;
     }
 
-    if (this.selection?.type === "edge") {
+    if (edge) {
       this.selectionSummary.textContent = "Connector selected";
       this.labelInput.value = "";
       this.widthInput.value = "";
       this.heightInput.value = "";
+      this.fillColorInput.value = DEFAULT_NODE_COLORS.fill;
+      this.strokeColorInput.value = DEFAULT_NODE_COLORS.stroke;
+      this.accentColorInput.value = this.normalizeColor(
+        edge.color || DEFAULT_EDGE_COLOR,
+      );
       this.inspectorNote.textContent =
-        "Connectors auto-snap to the nearest logical side of each shape while you move blocks around.";
+        "Use the Text / Arrow picker to recolor the selected connector while keeping its snap behavior.";
       return;
     }
 
@@ -587,6 +679,9 @@ class ProjectArchitect {
     this.labelInput.value = "";
     this.widthInput.value = "";
     this.heightInput.value = "";
+    this.fillColorInput.value = DEFAULT_NODE_COLORS.fill;
+    this.strokeColorInput.value = DEFAULT_NODE_COLORS.stroke;
+    this.accentColorInput.value = DEFAULT_EDGE_COLOR;
     this.inspectorNote.textContent =
       "Tip: in connect mode, click one shape and then another to draw a smart arrow.";
   }
@@ -655,10 +750,10 @@ class ProjectArchitect {
     const style = document.createElementNS(SVG_NS, "style");
     style.textContent = `
       .grid-line { fill: none; stroke: rgba(148, 163, 184, 0.16); stroke-width: 1; }
-      .arrow-head { fill: #38bdf8; }
-      .edge-path { fill: none; stroke: #38bdf8; stroke-width: 2.5; marker-end: url(#arrowhead); }
-      .node-shape { fill: rgba(15, 23, 42, 0.92); stroke: rgba(148, 163, 184, 0.65); stroke-width: 2; }
-      .node-label { fill: #e7edf7; font-family: "Plus Jakarta Sans", "Segoe UI", sans-serif; font-size: 16px; font-weight: 600; text-anchor: middle; dominant-baseline: middle; }
+      .arrow-head { fill: context-stroke; }
+      .edge-path { fill: none; stroke: ${DEFAULT_EDGE_COLOR}; stroke-width: 2.5; marker-end: url(#arrowhead); }
+      .node-shape { fill: ${DEFAULT_NODE_COLORS.fill}; stroke: ${DEFAULT_NODE_COLORS.stroke}; stroke-width: 2; }
+      .node-label { fill: ${DEFAULT_NODE_COLORS.text}; font-family: "Plus Jakarta Sans", "Segoe UI", sans-serif; font-size: 16px; font-weight: 600; text-anchor: middle; dominant-baseline: middle; }
     `;
     clone.insertBefore(style, clone.firstChild);
     return new XMLSerializer().serializeToString(clone);
@@ -690,6 +785,10 @@ class ProjectArchitect {
 
   titleCase(value) {
     return value.replace(/(^|\s|-)\w/g, (match) => match.toUpperCase());
+  }
+
+  normalizeColor(value) {
+    return /^#[0-9a-f]{6}$/i.test(value) ? value : "#000000";
   }
 }
 

--- a/assets/js/pages/project-architect.js
+++ b/assets/js/pages/project-architect.js
@@ -1,0 +1,699 @@
+const SVG_NS = "http://www.w3.org/2000/svg";
+const GRID_SIZE = 20;
+const DEFAULT_NODE_SIZE = {
+  terminator: { width: 180, height: 80 },
+  process: { width: 200, height: 100 },
+  decision: { width: 170, height: 120 },
+  input: { width: 200, height: 90 },
+};
+const DEFAULT_LABELS = {
+  terminator: "Start",
+  process: "Process",
+  decision: "Decision",
+  input: "Input / Output",
+};
+
+class ProjectArchitect {
+  constructor() {
+    this.canvas = document.getElementById("diagramCanvas");
+    this.stage = document.getElementById("canvasStage");
+    this.nodeLayer = document.getElementById("nodeLayer");
+    this.edgeLayer = document.getElementById("edgeLayer");
+    this.connectBtn = document.getElementById("connectBtn");
+    this.duplicateBtn = document.getElementById("duplicateBtn");
+    this.deleteBtn = document.getElementById("deleteBtn");
+    this.exportSvgBtn = document.getElementById("exportSvgBtn");
+    this.exportPngBtn = document.getElementById("exportPngBtn");
+    this.loadSampleBtn = document.getElementById("loadSampleBtn");
+    this.clearBoardBtn = document.getElementById("clearBoardBtn");
+    this.labelInput = document.getElementById("labelInput");
+    this.widthInput = document.getElementById("widthInput");
+    this.heightInput = document.getElementById("heightInput");
+    this.selectionSummary = document.getElementById("selectionSummary");
+    this.modePill = document.getElementById("modePill");
+    this.inspectorNote = document.getElementById("inspectorNote");
+    this.shapeButtons = Array.from(document.querySelectorAll(".shape-chip"));
+
+    this.nodes = [];
+    this.edges = [];
+    this.selection = null;
+    this.mode = "select";
+    this.connectSourceId = null;
+    this.dragState = null;
+    this.shapeInsertIndex = 0;
+  }
+
+  init() {
+    if (!this.canvas) {
+      return;
+    }
+
+    this.bindPalette();
+    this.bindCanvas();
+    this.bindToolbar();
+    this.bindInspector();
+    this.loadSampleDiagram();
+  }
+
+  bindPalette() {
+    this.shapeButtons.forEach((button) => {
+      const shape = button.dataset.shape;
+      button.addEventListener("click", () => this.addNode(shape));
+      button.addEventListener("dragstart", (event) => {
+        event.dataTransfer?.setData("text/plain", shape);
+        event.dataTransfer.effectAllowed = "copy";
+      });
+    });
+
+    this.stage.addEventListener("dragover", (event) => {
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "copy";
+      }
+    });
+
+    this.stage.addEventListener("drop", (event) => {
+      event.preventDefault();
+      const shape = event.dataTransfer?.getData("text/plain");
+      if (!shape) {
+        return;
+      }
+      const point = this.getSvgPoint(event.clientX, event.clientY);
+      this.addNode(shape, point.x, point.y);
+    });
+  }
+
+  bindCanvas() {
+    this.canvas.addEventListener("pointermove", (event) =>
+      this.handlePointerMove(event),
+    );
+    this.canvas.addEventListener("pointerup", () => this.stopDragging());
+    this.canvas.addEventListener("pointerleave", () => this.stopDragging());
+    this.canvas.addEventListener("pointercancel", () => this.stopDragging());
+    this.canvas.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      if (!target.closest(".node-group") && !target.closest(".edge-path")) {
+        this.clearSelection();
+      }
+    });
+  }
+
+  bindToolbar() {
+    this.connectBtn.addEventListener("click", () => this.toggleConnectMode());
+    this.duplicateBtn.addEventListener("click", () => this.duplicateSelection());
+    this.deleteBtn.addEventListener("click", () => this.deleteSelection());
+    this.exportSvgBtn.addEventListener("click", () => this.exportSvg());
+    this.exportPngBtn.addEventListener("click", () => this.exportPng());
+    this.loadSampleBtn.addEventListener("click", () => this.loadSampleDiagram());
+    this.clearBoardBtn.addEventListener("click", () => this.clearBoard());
+
+    document.addEventListener("keydown", (event) => {
+      const isInputFocused = ["INPUT", "TEXTAREA"].includes(
+        document.activeElement?.tagName,
+      );
+
+      if ((event.key === "Delete" || event.key === "Backspace") && !isInputFocused) {
+        event.preventDefault();
+        this.deleteSelection();
+      }
+
+      if (event.key === "Escape") {
+        this.mode = "select";
+        this.connectSourceId = null;
+        this.updateModeUI();
+        this.render();
+      }
+    });
+  }
+
+  bindInspector() {
+    this.labelInput.addEventListener("input", () => {
+      const node = this.getSelectedNode();
+      if (!node) {
+        return;
+      }
+      node.label = this.labelInput.value;
+      this.render();
+    });
+
+    this.widthInput.addEventListener("input", () => {
+      const node = this.getSelectedNode();
+      if (!node) {
+        return;
+      }
+      node.width = this.clampDimension(Number(this.widthInput.value), "width");
+      this.render();
+      this.updateInspector();
+    });
+
+    this.heightInput.addEventListener("input", () => {
+      const node = this.getSelectedNode();
+      if (!node) {
+        return;
+      }
+      node.height = this.clampDimension(Number(this.heightInput.value), "height");
+      this.render();
+      this.updateInspector();
+    });
+  }
+
+  addNode(shape, x, y) {
+    const id = `node-${crypto.randomUUID()}`;
+    const baseSize = DEFAULT_NODE_SIZE[shape] || DEFAULT_NODE_SIZE.process;
+    const position =
+      typeof x === "number" && typeof y === "number"
+        ? { x, y }
+        : {
+            x: 220 + (this.shapeInsertIndex % 3) * 250,
+            y: 140 + Math.floor(this.shapeInsertIndex / 3) * 150,
+          };
+
+    this.shapeInsertIndex += 1;
+
+    const node = {
+      id,
+      shape,
+      x: this.snap(position.x),
+      y: this.snap(position.y),
+      width: baseSize.width,
+      height: baseSize.height,
+      label: DEFAULT_LABELS[shape] || "Step",
+    };
+
+    this.nodes.push(node);
+    this.selectNode(id);
+    this.render();
+  }
+
+  createEdge(from, to) {
+    if (!from || !to || from === to) {
+      return;
+    }
+
+    const exists = this.edges.some(
+      (edge) => edge.from === from && edge.to === to,
+    );
+    if (exists) {
+      return;
+    }
+
+    this.edges.push({
+      id: `edge-${crypto.randomUUID()}`,
+      from,
+      to,
+    });
+    this.selection = { type: "edge", id: this.edges[this.edges.length - 1].id };
+    this.render();
+    this.updateInspector();
+  }
+
+  duplicateSelection() {
+    const node = this.getSelectedNode();
+    if (!node) {
+      return;
+    }
+
+    const clone = {
+      ...node,
+      id: `node-${crypto.randomUUID()}`,
+      x: this.snap(node.x + 40),
+      y: this.snap(node.y + 40),
+      label: `${node.label} Copy`,
+    };
+    this.nodes.push(clone);
+    this.selectNode(clone.id);
+    this.render();
+  }
+
+  deleteSelection() {
+    if (!this.selection) {
+      return;
+    }
+
+    if (this.selection.type === "node") {
+      const nodeId = this.selection.id;
+      this.nodes = this.nodes.filter((node) => node.id !== nodeId);
+      this.edges = this.edges.filter(
+        (edge) => edge.from !== nodeId && edge.to !== nodeId,
+      );
+    }
+
+    if (this.selection.type === "edge") {
+      this.edges = this.edges.filter((edge) => edge.id !== this.selection.id);
+    }
+
+    this.clearSelection();
+    this.render();
+  }
+
+  clearBoard() {
+    this.nodes = [];
+    this.edges = [];
+    this.shapeInsertIndex = 0;
+    this.clearSelection();
+    this.render();
+  }
+
+  loadSampleDiagram() {
+    this.nodes = [
+      {
+        id: "sample-start",
+        shape: "terminator",
+        x: 260,
+        y: 120,
+        width: 180,
+        height: 80,
+        label: "Start",
+      },
+      {
+        id: "sample-input",
+        shape: "input",
+        x: 260,
+        y: 260,
+        width: 210,
+        height: 90,
+        label: "Collect Inputs",
+      },
+      {
+        id: "sample-decision",
+        shape: "decision",
+        x: 650,
+        y: 260,
+        width: 180,
+        height: 120,
+        label: "Criteria Met?",
+      },
+      {
+        id: "sample-process",
+        shape: "process",
+        x: 650,
+        y: 450,
+        width: 220,
+        height: 100,
+        label: "Generate Output",
+      },
+      {
+        id: "sample-end",
+        shape: "terminator",
+        x: 960,
+        y: 450,
+        width: 180,
+        height: 80,
+        label: "End",
+      },
+    ];
+
+    this.edges = [
+      { id: "edge-1", from: "sample-start", to: "sample-input" },
+      { id: "edge-2", from: "sample-input", to: "sample-decision" },
+      { id: "edge-3", from: "sample-decision", to: "sample-process" },
+      { id: "edge-4", from: "sample-process", to: "sample-end" },
+    ];
+
+    this.selection = { type: "node", id: "sample-input" };
+    this.mode = "select";
+    this.connectSourceId = null;
+    this.shapeInsertIndex = this.nodes.length;
+    this.render();
+    this.updateInspector();
+  }
+
+  toggleConnectMode() {
+    this.mode = this.mode === "connect" ? "select" : "connect";
+    this.connectSourceId = null;
+    this.updateModeUI();
+    this.render();
+  }
+
+  selectNode(id) {
+    this.selection = { type: "node", id };
+    this.updateInspector();
+  }
+
+  selectEdge(id) {
+    this.selection = { type: "edge", id };
+    this.updateInspector();
+  }
+
+  clearSelection() {
+    this.selection = null;
+    this.connectSourceId = null;
+    this.updateInspector();
+    this.render();
+  }
+
+  getSelectedNode() {
+    if (!this.selection || this.selection.type !== "node") {
+      return null;
+    }
+    return this.nodes.find((node) => node.id === this.selection.id) || null;
+  }
+
+  handleNodeInteraction(node, event) {
+    event.stopPropagation();
+
+    if (this.mode === "connect") {
+      if (!this.connectSourceId) {
+        this.connectSourceId = node.id;
+        this.selectNode(node.id);
+        this.render();
+        return;
+      }
+
+      this.createEdge(this.connectSourceId, node.id);
+      this.connectSourceId = null;
+      this.mode = "select";
+      this.updateModeUI();
+      return;
+    }
+
+    this.selectNode(node.id);
+    const point = this.getSvgPoint(event.clientX, event.clientY);
+    this.dragState = {
+      nodeId: node.id,
+      deltaX: point.x - node.x,
+      deltaY: point.y - node.y,
+    };
+  }
+
+  handlePointerMove(event) {
+    if (!this.dragState) {
+      return;
+    }
+
+    const node = this.nodes.find((item) => item.id === this.dragState.nodeId);
+    if (!node) {
+      return;
+    }
+
+    const point = this.getSvgPoint(event.clientX, event.clientY);
+    node.x = this.snap(point.x - this.dragState.deltaX);
+    node.y = this.snap(point.y - this.dragState.deltaY);
+    this.render();
+    this.updateInspector();
+  }
+
+  stopDragging() {
+    this.dragState = null;
+  }
+
+  render() {
+    this.renderEdges();
+    this.renderNodes();
+    this.updateModeUI();
+  }
+
+  renderNodes() {
+    this.nodeLayer.textContent = "";
+
+    this.nodes.forEach((node) => {
+      const group = document.createElementNS(SVG_NS, "g");
+      group.classList.add("node-group");
+      group.dataset.nodeId = node.id;
+
+      if (this.selection?.type === "node" && this.selection.id === node.id) {
+        group.classList.add("selected");
+      }
+
+      if (this.connectSourceId === node.id) {
+        group.classList.add("connect-source");
+      }
+
+      const shape = this.createNodeShape(node);
+      shape.classList.add("node-shape");
+      group.appendChild(shape);
+
+      const text = document.createElementNS(SVG_NS, "text");
+      text.setAttribute("x", String(node.x));
+      text.setAttribute("y", String(node.y));
+      text.setAttribute("class", "node-label");
+      text.textContent = node.label;
+      group.appendChild(text);
+
+      group.addEventListener("pointerdown", (event) =>
+        this.handleNodeInteraction(node, event),
+      );
+
+      this.nodeLayer.appendChild(group);
+    });
+  }
+
+  createNodeShape(node) {
+    switch (node.shape) {
+      case "terminator":
+        return this.createRoundedRect(node, 40);
+      case "decision":
+        return this.createDiamond(node);
+      case "input":
+        return this.createInputShape(node);
+      case "process":
+      default:
+        return this.createRoundedRect(node, 18);
+    }
+  }
+
+  createRoundedRect(node, radius) {
+    const rect = document.createElementNS(SVG_NS, "rect");
+    rect.setAttribute("x", String(node.x - node.width / 2));
+    rect.setAttribute("y", String(node.y - node.height / 2));
+    rect.setAttribute("width", String(node.width));
+    rect.setAttribute("height", String(node.height));
+    rect.setAttribute("rx", String(radius));
+    rect.setAttribute("ry", String(radius));
+    return rect;
+  }
+
+  createDiamond(node) {
+    const polygon = document.createElementNS(SVG_NS, "polygon");
+    const halfWidth = node.width / 2;
+    const halfHeight = node.height / 2;
+    polygon.setAttribute(
+      "points",
+      [
+        `${node.x},${node.y - halfHeight}`,
+        `${node.x + halfWidth},${node.y}`,
+        `${node.x},${node.y + halfHeight}`,
+        `${node.x - halfWidth},${node.y}`,
+      ].join(" "),
+    );
+    return polygon;
+  }
+
+  createInputShape(node) {
+    const polygon = document.createElementNS(SVG_NS, "polygon");
+    const left = node.x - node.width / 2;
+    const top = node.y - node.height / 2;
+    const skew = 26;
+    polygon.setAttribute(
+      "points",
+      [
+        `${left + skew},${top}`,
+        `${left + node.width},${top}`,
+        `${left + node.width - skew},${top + node.height}`,
+        `${left},${top + node.height}`,
+      ].join(" "),
+    );
+    return polygon;
+  }
+
+  renderEdges() {
+    this.edgeLayer.textContent = "";
+
+    this.edges.forEach((edge) => {
+      const fromNode = this.nodes.find((node) => node.id === edge.from);
+      const toNode = this.nodes.find((node) => node.id === edge.to);
+
+      if (!fromNode || !toNode) {
+        return;
+      }
+
+      const path = document.createElementNS(SVG_NS, "path");
+      path.setAttribute("class", "edge-path");
+      path.dataset.edgeId = edge.id;
+      path.setAttribute("d", this.buildConnectorPath(fromNode, toNode));
+
+      if (this.selection?.type === "edge" && this.selection.id === edge.id) {
+        path.classList.add("selected");
+      }
+
+      path.addEventListener("click", (event) => {
+        event.stopPropagation();
+        this.selectEdge(edge.id);
+        this.render();
+      });
+
+      this.edgeLayer.appendChild(path);
+    });
+  }
+
+  buildConnectorPath(fromNode, toNode) {
+    const start = this.getAnchorPoint(fromNode, toNode);
+    const end = this.getAnchorPoint(toNode, fromNode);
+    const midX = this.snap((start.x + end.x) / 2);
+    return `M ${start.x} ${start.y} C ${midX} ${start.y}, ${midX} ${end.y}, ${end.x} ${end.y}`;
+  }
+
+  getAnchorPoint(node, target) {
+    const dx = target.x - node.x;
+    const dy = target.y - node.y;
+    const halfWidth = node.width / 2;
+    const halfHeight = node.height / 2;
+
+    if (Math.abs(dx) > Math.abs(dy)) {
+      return {
+        x: this.snap(node.x + Math.sign(dx || 1) * halfWidth),
+        y: this.snap(node.y),
+      };
+    }
+
+    return {
+      x: this.snap(node.x),
+      y: this.snap(node.y + Math.sign(dy || 1) * halfHeight),
+    };
+  }
+
+  updateInspector() {
+    const node = this.getSelectedNode();
+    const hasNode = Boolean(node);
+
+    this.labelInput.disabled = !hasNode;
+    this.widthInput.disabled = !hasNode;
+    this.heightInput.disabled = !hasNode;
+
+    if (node) {
+      this.selectionSummary.textContent = `${this.titleCase(node.shape)} node selected`;
+      this.labelInput.value = node.label;
+      this.widthInput.value = String(node.width);
+      this.heightInput.value = String(node.height);
+      this.inspectorNote.textContent =
+        "Resize in clean 20px steps to keep the flowchart aligned on the academic grid.";
+      return;
+    }
+
+    if (this.selection?.type === "edge") {
+      this.selectionSummary.textContent = "Connector selected";
+      this.labelInput.value = "";
+      this.widthInput.value = "";
+      this.heightInput.value = "";
+      this.inspectorNote.textContent =
+        "Connectors auto-snap to the nearest logical side of each shape while you move blocks around.";
+      return;
+    }
+
+    this.selectionSummary.textContent = "No element selected";
+    this.labelInput.value = "";
+    this.widthInput.value = "";
+    this.heightInput.value = "";
+    this.inspectorNote.textContent =
+      "Tip: in connect mode, click one shape and then another to draw a smart arrow.";
+  }
+
+  updateModeUI() {
+    const isConnectMode = this.mode === "connect";
+    this.connectBtn.classList.toggle("btn-primary", isConnectMode);
+    this.connectBtn.classList.toggle("btn-secondary", !isConnectMode);
+    this.modePill.textContent = isConnectMode
+      ? this.connectSourceId
+        ? "Pick destination node"
+        : "Connect mode"
+      : "Select mode";
+  }
+
+  exportSvg() {
+    const svgText = this.buildExportSvg();
+    const blob = new Blob([svgText], { type: "image/svg+xml;charset=utf-8" });
+    this.downloadBlob(blob, "college-daddy-project-architect.svg");
+  }
+
+  exportPng() {
+    const svgText = this.buildExportSvg();
+    const svgBlob = new Blob([svgText], {
+      type: "image/svg+xml;charset=utf-8",
+    });
+    const url = URL.createObjectURL(svgBlob);
+    const image = new Image();
+    const canvas = document.createElement("canvas");
+    const { width, height } = this.canvas.viewBox.baseVal;
+    canvas.width = width;
+    canvas.height = height;
+
+    image.onload = () => {
+      const context = canvas.getContext("2d");
+      if (!context) {
+        URL.revokeObjectURL(url);
+        return;
+      }
+      context.drawImage(image, 0, 0);
+      canvas.toBlob((blob) => {
+        if (blob) {
+          this.downloadBlob(blob, "college-daddy-project-architect.png");
+        }
+        URL.revokeObjectURL(url);
+      });
+    };
+
+    image.src = url;
+  }
+
+  downloadBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  buildExportSvg() {
+    const clone = this.canvas.cloneNode(true);
+    clone.setAttribute("xmlns", SVG_NS);
+    const style = document.createElementNS(SVG_NS, "style");
+    style.textContent = `
+      .grid-line { fill: none; stroke: rgba(148, 163, 184, 0.16); stroke-width: 1; }
+      .arrow-head { fill: #38bdf8; }
+      .edge-path { fill: none; stroke: #38bdf8; stroke-width: 2.5; marker-end: url(#arrowhead); }
+      .node-shape { fill: rgba(15, 23, 42, 0.92); stroke: rgba(148, 163, 184, 0.65); stroke-width: 2; }
+      .node-label { fill: #e7edf7; font-family: "Plus Jakarta Sans", "Segoe UI", sans-serif; font-size: 16px; font-weight: 600; text-anchor: middle; dominant-baseline: middle; }
+    `;
+    clone.insertBefore(style, clone.firstChild);
+    return new XMLSerializer().serializeToString(clone);
+  }
+
+  getSvgPoint(clientX, clientY) {
+    const point = this.canvas.createSVGPoint();
+    point.x = clientX;
+    point.y = clientY;
+    const transformed = point.matrixTransform(
+      this.canvas.getScreenCTM()?.inverse(),
+    );
+    return transformed;
+  }
+
+  snap(value) {
+    return Math.round(value / GRID_SIZE) * GRID_SIZE;
+  }
+
+  clampDimension(value, axis) {
+    if (Number.isNaN(value)) {
+      return axis === "width" ? 180 : 80;
+    }
+    if (axis === "width") {
+      return Math.min(320, Math.max(80, this.snap(value)));
+    }
+    return Math.min(220, Math.max(60, this.snap(value)));
+  }
+
+  titleCase(value) {
+    return value.replace(/(^|\s|-)\w/g, (match) => match.toUpperCase());
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const architect = new ProjectArchitect();
+  architect.init();
+});

--- a/index.html
+++ b/index.html
@@ -113,6 +113,9 @@
           <a href="pages/notes.html" class="nav-link">Notes</a>
           <a href="pages/roadmap.html" class="nav-link">Roadmap</a>
           <a href="pages/events.html" class="nav-link">Events</a>
+          <a href="pages/project-architect.html" class="nav-link"
+            >Architect</a
+          >
           <button
             class="theme-toggle"
             aria-label="Toggle dark/light theme"
@@ -237,6 +240,19 @@
           <p>
             Explore top platforms, tutorials, and practice sites for mastering
             Competitive Programming and Data Structures & Algorithms.
+          </p>
+        </div>
+        <div
+          class="feature-card"
+          data-aos="fade-up"
+          data-aos-delay="700"
+          data-url="pages/project-architect.html"
+        >
+          <div class="feature-icon">🧭</div>
+          <h3>Project Architect</h3>
+          <p>
+            Create report-ready flowcharts and system diagrams with smart
+            connectors, clean 2D shapes, and instant PNG or SVG export.
           </p>
         </div>
       </div>

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -39,6 +39,7 @@
         <a href="notes.html" class="nav-link active">Notes</a>
         <a href="roadmap.html" class="nav-link">Roadmap</a>
         <a href="events.html" class="nav-link">Events</a>
+        <a href="project-architect.html" class="nav-link">Architect</a>
         <button class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
           <span class="theme-icon">🌙</span>
         </button>

--- a/pages/attendance.html
+++ b/pages/attendance.html
@@ -65,6 +65,7 @@
           <a href="notes.html" class="nav-link">Notes</a>
           <a href="roadmap.html" class="nav-link">Roadmap</a>
           <a href="events.html" class="nav-link">Events</a>
+          <a href="project-architect.html" class="nav-link">Architect</a>
           <button class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <span class="theme-icon">🌙</span>
           </button>

--- a/pages/cgpa.html
+++ b/pages/cgpa.html
@@ -88,6 +88,7 @@
                 <a href="notes.html" class="nav-link">Notes</a>
                 <a href="roadmap.html" class="nav-link">Roadmap</a>
                 <a href="events.html" class="nav-link">Events</a>
+                <a href="project-architect.html" class="nav-link">Architect</a>
                 <button class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
                     <span class="theme-icon">🌙</span>
                 </button>

--- a/pages/chat.html
+++ b/pages/chat.html
@@ -47,6 +47,7 @@
           <a href="notes.html" class="nav-link active">Notes</a>
           <a href="roadmap.html" class="nav-link">Roadmap</a>
           <a href="events.html" class="nav-link">Events</a>
+          <a href="project-architect.html" class="nav-link">Architect</a>
           <button
             class="theme-toggle"
             aria-label="Toggle dark/light theme"

--- a/pages/cpdsa.html
+++ b/pages/cpdsa.html
@@ -50,6 +50,7 @@
           <a href="cpdsa.html" class="nav-link active">CP & DSA</a>
           <a href="roadmap.html" class="nav-link">Roadmap</a>
           <a href="events.html" class="nav-link">Events</a>
+          <a href="project-architect.html" class="nav-link">Architect</a>
           <button
             class="theme-toggle"
             aria-label="Toggle dark/light theme"

--- a/pages/events.html
+++ b/pages/events.html
@@ -60,6 +60,7 @@
           <a href="notes.html" class="nav-link">Notes</a>
           <a href="roadmap.html" class="nav-link">Roadmap</a>
           <a href="events.html" class="nav-link active">Events</a>
+          <a href="project-architect.html" class="nav-link">Architect</a>
 
           <button
             class="theme-toggle"

--- a/pages/iacal.html
+++ b/pages/iacal.html
@@ -54,6 +54,7 @@
                 <a href="notes.html" class="nav-link">Notes</a>
                 <a href="roadmap.html" class="nav-link">Roadmap</a>
                 <a href="events.html" class="nav-link">Events</a>
+                <a href="project-architect.html" class="nav-link">Architect</a>
                 <button
                     class="theme-toggle"
                     aria-label="Toggle dark/light theme"
@@ -342,7 +343,6 @@
 <script src="../assets/js/components/back-to-top.js"></script>
 </body>
 </html>
-
 
 
 

--- a/pages/notes.html
+++ b/pages/notes.html
@@ -49,6 +49,7 @@
           <a href="notes.html" class="nav-link active">Notes</a>
           <a href="roadmap.html" class="nav-link">Roadmap</a>
           <a href="events.html" class="nav-link">Events</a>
+          <a href="project-architect.html" class="nav-link">Architect</a>
           <button
             class="theme-toggle"
             aria-label="Toggle dark/light theme"

--- a/pages/pomodoro.html
+++ b/pages/pomodoro.html
@@ -364,6 +364,7 @@
                 <a href="notes.html" class="nav-link">Notes</a>
                 <a href="roadmap.html" class="nav-link">Roadmap</a>
                 <a href="events.html" class="nav-link">Events</a>
+                <a href="project-architect.html" class="nav-link">Architect</a>
                 <div class="timer-nav-controls">
                     <div class="settings-icon" id="settings-icon" aria-label="Timer settings" title="Settings"></div>
                     <button id="fullscreenBtn" class="fullscreen-btn" aria-label="Toggle fullscreen" title="Fullscreen">

--- a/pages/progress.html
+++ b/pages/progress.html
@@ -54,6 +54,7 @@
                 <a href="notes.html" class="nav-link">Notes</a>
                 <a href="roadmap.html" class="nav-link">Roadmap</a>
                 <a href="events.html" class="nav-link">Events</a>
+                <a href="project-architect.html" class="nav-link">Architect</a>
 
                 <button
                     class="theme-toggle"

--- a/pages/project-architect.html
+++ b/pages/project-architect.html
@@ -1,0 +1,276 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>College Daddy - Project Architect</title>
+    <link rel="icon" type="image/png" href="../assets/img/favicon.png" />
+    <link rel="stylesheet" href="../assets/css/navigation.css" />
+    <link rel="stylesheet" href="../assets/css/global.css" />
+    <link rel="stylesheet" href="../assets/css/footer.css" />
+    <link rel="stylesheet" href="../assets/css/project-architect.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
+      integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <script>
+      (function () {
+        try {
+          const theme = localStorage.getItem("theme") || "dark";
+          document.documentElement.setAttribute("data-theme", theme);
+        } catch (e) {
+          document.documentElement.setAttribute("data-theme", "dark");
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a href="../index.html" class="logo" aria-label="College Daddy Home">
+          <i class="fas fa-graduation-cap" aria-hidden="true"></i>
+          <span>College Daddy</span>
+        </a>
+        <div class="nav-actions">
+          <button
+            class="menu-button"
+            aria-label="Toggle navigation menu"
+            aria-expanded="false"
+          >
+            ☰
+          </button>
+        </div>
+        <nav class="nav-links">
+          <a href="../index.html" class="nav-link">Home</a>
+          <a href="cgpa.html" class="nav-link">CGPA Calculator</a>
+          <a href="iacal.html" class="nav-link">IA Calculator</a>
+          <a href="attendance.html" class="nav-link">Attendance</a>
+          <a href="pomodoro.html" class="nav-link">Study Timer</a>
+          <a href="notes.html" class="nav-link">Notes</a>
+          <a href="roadmap.html" class="nav-link">Roadmap</a>
+          <a href="events.html" class="nav-link">Events</a>
+          <a href="project-architect.html" class="nav-link active"
+            >Architect</a
+          >
+          <button
+            class="theme-toggle"
+            aria-label="Toggle dark/light theme"
+            title="Toggle theme"
+          >
+            <span class="theme-icon">🌙</span>
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main class="architect-page">
+      <section class="architect-hero container">
+        <div class="hero-copy">
+          <span class="eyebrow">Professional diagram maker</span>
+          <h1>Project Architect</h1>
+          <p>
+            Build crisp flowcharts and system diagrams for lab records, mini
+            projects, and documentation without leaving College Daddy.
+          </p>
+          <div class="hero-points">
+            <span>Grid-snapped 2D canvas</span>
+            <span>Shape-aware connectors</span>
+            <span>PNG and SVG export</span>
+          </div>
+        </div>
+        <div class="hero-card card">
+          <h2>How it works</h2>
+          <ol>
+            <li>Drag a shape from the palette or click to insert it.</li>
+            <li>Move blocks around and connect them in one click.</li>
+            <li>Edit labels, then export the final diagram for your report.</li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="architect-shell container">
+        <aside class="architect-panel card palette-panel">
+          <div class="panel-heading">
+            <h2>Elements</h2>
+            <p>Drag onto the canvas or click to add.</p>
+          </div>
+
+          <div class="shape-palette" role="list" aria-label="Diagram shapes">
+            <button
+              class="shape-chip"
+              data-shape="terminator"
+              draggable="true"
+              type="button"
+            >
+              <span class="shape-preview preview-pill"></span>
+              Start / End
+            </button>
+            <button
+              class="shape-chip"
+              data-shape="process"
+              draggable="true"
+              type="button"
+            >
+              <span class="shape-preview preview-rect"></span>
+              Process
+            </button>
+            <button
+              class="shape-chip"
+              data-shape="decision"
+              draggable="true"
+              type="button"
+            >
+              <span class="shape-preview preview-diamond"></span>
+              Decision
+            </button>
+            <button
+              class="shape-chip"
+              data-shape="input"
+              draggable="true"
+              type="button"
+            >
+              <span class="shape-preview preview-input"></span>
+              Input / Output
+            </button>
+          </div>
+
+          <div class="starter-actions">
+            <button class="btn btn-secondary" id="loadSampleBtn" type="button">
+              Load Sample Flow
+            </button>
+            <button class="btn btn-secondary" id="clearBoardBtn" type="button">
+              Clear Board
+            </button>
+          </div>
+        </aside>
+
+        <section class="canvas-column">
+          <div class="workspace-toolbar card" aria-label="Canvas tools">
+            <div class="toolbar-group">
+              <button class="btn btn-primary" id="connectBtn" type="button">
+                Connect Nodes
+              </button>
+              <button class="btn btn-secondary" id="duplicateBtn" type="button">
+                Duplicate
+              </button>
+              <button class="btn btn-secondary" id="deleteBtn" type="button">
+                Delete
+              </button>
+            </div>
+            <div class="toolbar-group">
+              <button class="btn btn-secondary" id="exportSvgBtn" type="button">
+                Export SVG
+              </button>
+              <button class="btn btn-secondary" id="exportPngBtn" type="button">
+                Export PNG
+              </button>
+            </div>
+          </div>
+
+          <div class="canvas-card card">
+            <div class="canvas-meta">
+              <div>
+                <h2>Diagram Canvas</h2>
+                <p>Snap-enabled workspace for polished academic diagrams.</p>
+              </div>
+              <span class="mode-pill" id="modePill">Select mode</span>
+            </div>
+
+            <div class="canvas-stage" id="canvasStage">
+              <svg
+                id="diagramCanvas"
+                class="diagram-canvas"
+                viewBox="0 0 1200 760"
+                role="img"
+                aria-label="Project Architect drawing canvas"
+              >
+                <defs>
+                  <marker
+                    id="arrowhead"
+                    markerWidth="12"
+                    markerHeight="12"
+                    refX="10"
+                    refY="6"
+                    orient="auto"
+                    markerUnits="strokeWidth"
+                  >
+                    <path d="M0,0 L12,6 L0,12 z" class="arrow-head"></path>
+                  </marker>
+                  <pattern
+                    id="gridPattern"
+                    width="20"
+                    height="20"
+                    patternUnits="userSpaceOnUse"
+                  >
+                    <path d="M 20 0 L 0 0 0 20" class="grid-line"></path>
+                  </pattern>
+                </defs>
+                <rect width="1200" height="760" fill="url(#gridPattern)"></rect>
+                <g id="edgeLayer"></g>
+                <g id="nodeLayer"></g>
+              </svg>
+            </div>
+          </div>
+        </section>
+
+        <aside class="architect-panel card inspector-panel">
+          <div class="panel-heading">
+            <h2>Inspector</h2>
+            <p>Adjust the selected block or connector.</p>
+          </div>
+
+          <div class="inspector-state" id="selectionSummary">
+            No element selected
+          </div>
+
+          <label class="field">
+            <span>Label</span>
+            <input
+              id="labelInput"
+              type="text"
+              placeholder="Select a node to rename"
+              disabled
+            />
+          </label>
+
+          <div class="size-grid">
+            <label class="field">
+              <span>Width</span>
+              <input
+                id="widthInput"
+                type="number"
+                min="80"
+                max="320"
+                step="20"
+                disabled
+              />
+            </label>
+            <label class="field">
+              <span>Height</span>
+              <input
+                id="heightInput"
+                type="number"
+                min="60"
+                max="220"
+                step="20"
+                disabled
+              />
+            </label>
+          </div>
+
+          <div class="inspector-note" id="inspectorNote">
+            Tip: in connect mode, click one shape and then another to draw a
+            smart arrow.
+          </div>
+        </aside>
+      </section>
+    </main>
+
+    <script src="../assets/js/components/navigation.js" defer></script>
+    <script src="../assets/js/components/footer.js"></script>
+    <script src="../assets/js/pages/project-architect.js"></script>
+  </body>
+</html>

--- a/pages/project-architect.html
+++ b/pages/project-architect.html
@@ -261,6 +261,21 @@
             </label>
           </div>
 
+          <div class="color-grid">
+            <label class="field">
+              <span>Fill</span>
+              <input id="fillColorInput" type="color" disabled />
+            </label>
+            <label class="field">
+              <span>Border</span>
+              <input id="strokeColorInput" type="color" disabled />
+            </label>
+            <label class="field">
+              <span>Text / Arrow</span>
+              <input id="accentColorInput" type="color" disabled />
+            </label>
+          </div>
+
           <div class="inspector-note" id="inspectorNote">
             Tip: in connect mode, click one shape and then another to draw a
             smart arrow.

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -80,6 +80,7 @@
                 <a href="notes.html" class="nav-link">Notes</a>
                 <a href="roadmap.html" class="nav-link">Roadmap</a>
                 <a href="events.html" class="nav-link">Events</a>
+                <a href="project-architect.html" class="nav-link">Architect</a>
 
                 <button class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
                     <span class="theme-icon">🌙</span>


### PR DESCRIPTION
This PR adds the Project Architect feature from #256.

The main idea was to create a simple built-in workspace where students can make flowcharts and project diagrams without having to open external websites every time they need something for a report or assignment.

I tried to keep the overall experience lightweight and straightforward instead of making it feel like a full design tool.

Changes Made
Added a new Project Architect page
Built the editor layout and interactions
Added dedicated styling for the workspace
Integrated Project Architect into shared navigation
Added links/promotional sections across landing pages
Added color customization controls for the workspace

Testing
Checked navigation and routing across updated pages
Tested workspace rendering and interactions
Verified responsive behavior on different screen sizes
Tested customization controls

<img width="1509" height="775" alt="Screenshot 2026-05-18 at 10 28 38 PM" src="https://github.com/user-attachments/assets/c0a6aab9-094b-489a-85ed-94f019a99637" />

<img width="1509" height="775" alt="Screenshot 2026-05-18 at 10 30 06 PM" src="https://github.com/user-attachments/assets/93c7ae17-212c-4b19-8dbc-59e00d35ca4b" />