### PR TITLE
fix: add payload size limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from groq import Groq
 load_dotenv()
 
 app = Flask(__name__, static_folder='assets', template_folder='pages')
+app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024 # 16 MB max upload size
 CORS(app)
 
 UPLOAD_ROOT = 'data/notes'


### PR DESCRIPTION
This PR fixes critical stability and security vulnerabilities identified in the NSoC level 3 audit assignment. Added payload size limits to prevent DoS attacks. Fixes #278