### PR TITLE
[Feature]: Add Back to Top scroll button across all pagesFeature/back to top button

### DIFF
--- a/assets/css/back-to-top.css
+++ b/assets/css/back-to-top.css
@@ -1,0 +1,28 @@
+#backToTopBtn {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  z-index: 9999;
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  background-color: var(--primary-color, #6c63ff);
+  color: white;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+#backToTopBtn:hover {
+  transform: translateY(-3px);
+  opacity: 0.9;
+}
+
+#backToTopBtn.show {
+  display: flex;
+}

--- a/assets/css/back-to-top.css
+++ b/assets/css/back-to-top.css
@@ -20,7 +20,30 @@
 
 #backToTopBtn:hover {
   transform: translateY(-3px);
+  opacity: 0.9;#backToTopBtn {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  z-index: 9999;
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  background-color: #6c63ff;
+  color: white;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+#backToTopBtn:hover {
+  transform: translateY(-3px);
   opacity: 0.9;
+}
 }
 
 #backToTopBtn.show {

--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -1,0 +1,12 @@
+window.addEventListener('scroll', function () {
+  const btn = document.getElementById('backToTopBtn');
+  if (window.scrollY > 300) {
+    btn.classList.add('show');
+  } else {
+    btn.classList.remove('show');
+  }
+});
+
+document.getElementById('backToTopBtn').addEventListener('click', function () {
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+});

--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -1,12 +1,17 @@
 window.addEventListener('scroll', function () {
   const btn = document.getElementById('backToTopBtn');
+  if (!btn) return;
   if (window.scrollY > 300) {
-    btn.classList.add('show');
+    btn.style.display = 'flex';
   } else {
-    btn.classList.remove('show');
+    btn.style.display = 'none';
   }
 });
 
-document.getElementById('backToTopBtn').addEventListener('click', function () {
-  window.scrollTo({ top: 0, behavior: 'smooth' });
+document.addEventListener('DOMContentLoaded', function () {
+  const btn = document.getElementById('backToTopBtn');
+  if (!btn) return;
+  btn.addEventListener('click', function () {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
 });

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
     <link rel="stylesheet" href="assets/css/global.css" />
     <link rel="stylesheet" href="assets/css/footer.css" />
     <link rel="stylesheet" href="assets/css/hero.css" />
+    <link rel="stylesheet" href="assets/css/back-to-top.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
@@ -651,5 +652,8 @@
         window.addEventListener("offline", updateStatus);
       });
     </script>
+  <!-- Back to Top Button -->
+  <button id="backToTopBtn" title="Back to Top">↑</button>
+  <script src="assets/js/back-to-top.js"></script>
   </body>
 </html>

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -93,6 +93,14 @@
   <script src="../assets/js/components/navigation.js"></script>
   <script src="../assets/js/components/footer.js"></script>
   <script src="../assets/js/pages/admin.js"></script>
-  <script src="../assets/js/components/back-to-top.js"></script>
+  
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/attendance.html
+++ b/pages/attendance.html
@@ -263,5 +263,13 @@
 
     <!-- Page-specific logic -->
     <script src="../assets/js/pages/attendance.js"></script>
-  </body>
+  <!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+</body>
 </html>

--- a/pages/cgpa.html
+++ b/pages/cgpa.html
@@ -439,7 +439,15 @@
         </section>
     </main>
 
-<script src="../assets/js/components/back-to-top.js"></script>
+
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
 </body>
 
 </html>

--- a/pages/chat.html
+++ b/pages/chat.html
@@ -91,5 +91,13 @@
 
     <script src="../assets/js/components/navigation.js" defer></script>
     <script src="../assets/js/pages/chat.js"></script>
-  </body>
+  <!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+</body>
 </html>

--- a/pages/cpdsa.html
+++ b/pages/cpdsa.html
@@ -143,6 +143,14 @@
     <script src="../assets/js/components/navigation.js"></script>
     <script src="../assets/js/components/footer.js"></script>
 
-  <script src="../assets/js/components/back-to-top.js"></script>
+  
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/events.html
+++ b/pages/events.html
@@ -136,6 +136,14 @@
     <script src="../assets/js/components/navigation.js"></script>
     <script src="../assets/js/components/footer.js"></script>
     <script src="../assets/js/pages/events.js"></script>
-    <script src="../assets/js/components/back-to-top.js"></script>
-  </body>
+    
+  <!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+</body>
 </html>

--- a/pages/iacal.html
+++ b/pages/iacal.html
@@ -373,7 +373,15 @@
     <script src="../assets/js/pages/ia-dashboard.js" defer></script>
     <script src="../assets/js/pages/ia.js"></script>
     
-<script src="../assets/js/components/back-to-top.js"></script>
+
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>
 

--- a/pages/notes.html
+++ b/pages/notes.html
@@ -83,6 +83,14 @@
     <script src="../assets/js/pages/notes/notes-search.js"></script>
     <script src="../assets/js/pages/notes/notes-main.js"></script>
 
-    <script src="../assets/js/components/back-to-top.js"></script>
-  </body>
+    
+  <!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+</body>
 </html>

--- a/pages/pomodoro.html
+++ b/pages/pomodoro.html
@@ -756,7 +756,7 @@
         }
     });
     </script>
-<script src="../assets/js/components/back-to-top.js"></script>
+
         <!-- SECTION 3: QUIZ MODAL -->
         <div class="quiz-modal-overlay" id="quiz-modal">
             <div class="quiz-modal-content">
@@ -790,5 +790,13 @@
                 </div>
             </div>
         </div>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/progress.html
+++ b/pages/progress.html
@@ -324,6 +324,14 @@
         }
     });
     </script>
-<script src="../assets/js/components/back-to-top.js"></script>
+
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/project-architect.html
+++ b/pages/project-architect.html
@@ -287,5 +287,13 @@
     <script src="../assets/js/components/navigation.js" defer></script>
     <script src="../assets/js/components/footer.js"></script>
     <script src="../assets/js/pages/project-architect.js"></script>
-  </body>
+  <!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+</body>
 </html>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -345,7 +345,15 @@
     <script src="../assets/js/components/navigation.js" defer></script>
     <script src="../assets/js/components/footer.js"></script>
     <script src="../assets/js/pages/roadmap.js" defer></script>
-<script src="../assets/js/components/back-to-top.js"></script>
+
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
 </body>
 
 </html>

--- a/pages/typing.html
+++ b/pages/typing.html
@@ -129,6 +129,14 @@
 
     <script src="../assets/js/pages/typing.js"></script>
     <script src="../assets/js/components/footer.js"></script>
-    <script src="../assets/js/components/back-to-top.js"></script>
+    
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
+<!-- Back to Top Button -->
+<button id="backToTopBtn" title="Back to Top">↑</button>
+<link rel="stylesheet" href="../assets/css/back-to-top.css">
+<script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Pull Request Summary
Added a floating "Back to Top" scroll button across all pages of College Daddy. This improves UX on long pages like Notes, Roadmaps, and CGPA Calculator.

Closes #291
---

## Changes Introduced
- Created assets/css/back-to-top.css with fixed positioning and hover animation
- Created assets/js/back-to-top.js with scroll detection and smooth scroll logic
- Added button to index.html
- Added button to all 13 pages inside /pages folder
---
## Screenshots / Demo (for UI changes)
If applicable, include before-and-after visuals to illustrate the impact.
| Before | After |
|
<img width="1511" height="854" alt="image" src="https://github.com/user-attachments/assets/2b90647f-1646-4e18-abf6-fea697fa8ce1" />
|<img width="1492" height="912" alt="image" src="https://github.com/user-attachments/assets/86b483a5-953e-4093-b443-591de6fb6fb0" />|



---

## Checklist
Please ensure the following before requesting review:
- [x] Code follows project conventions and best practices.  
- [x] Feature or fix works correctly on both mobile and desktop.  
- [x] No new console errors or accessibility regressions.  
- [x] Documentation updated if applicable.  
- [x] Visuals attached for UI-related updates.  

---

## Additional Notes
Button is styled to match the existing dark theme. Uses vanilla JS with no external dependencies.