### PR TITLE
fix(quiz): cap question count at 20 and rate-limit /api/quiz/generate to 10 requests per minute

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, request, jsonify, send_from_directory, render_template, redirect
 from flask_cors import CORS
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 import os
 import json
 from werkzeug.utils import secure_filename
@@ -18,6 +20,15 @@ load_dotenv()
 app = Flask(__name__, static_folder='assets', template_folder='pages')
 app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024 # 16 MB max upload size
 CORS(app)
+
+limiter = Limiter(
+    get_remote_address,
+    app=app,
+    default_limits=[],
+    storage_uri="memory://",
+)
+
+MAX_QUIZ_QUESTIONS = 20
 
 UPLOAD_ROOT = 'data/notes'
 NOTES_JSON = 'data/notes-data.json'
@@ -272,15 +283,16 @@ def delete_material():
         return jsonify({'success': False, 'message': f'Error: {str(e)}'}), 500
 
 @app.route('/api/quiz/generate', methods=['POST'])
+@limiter.limit("10 per minute")
 def generate_quiz():
     if request.is_json:
         data = request.get_json()
         topic = data.get('topic', 'General Knowledge')
-        count = data.get('count', 5)
+        count = min(int(data.get('count', 5)), MAX_QUIZ_QUESTIONS)
         file = None
     else:
         topic = request.form.get('topic', 'General Knowledge')
-        count = int(request.form.get('count', 5))
+        count = min(int(request.form.get('count', 5)), MAX_QUIZ_QUESTIONS)
         file = request.files.get('file')
     
     api_key = os.getenv("GROQ_API_KEY")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==2.3.3
 Flask-CORS==4.0.0
+Flask-Limiter==3.5.0
 Werkzeug==2.3.7
 Pillow>=10.2.0
 pdf2image==1.16.3


### PR DESCRIPTION
## Pull Request Summary

The `/api/quiz/generate` endpoint had no upper bound on the `count` parameter and no rate limiting. A caller could send `count=100000` to a single request, forcing the Groq LLM to attempt an enormous quiz and exhausting all available tokens in one call. Combined with unlimited concurrent requests, this could drain the project's Groq API quota within seconds and block the feature for all users.

Fixes #290

---

## Changes Introduced

- **`app.py`**: Added `Flask-Limiter` import and wired a per-IP `Limiter` instance to the Flask app using in-memory storage with no global default limit so only explicitly decorated routes are throttled.
- **`app.py`**: Added `MAX_QUIZ_QUESTIONS = 20` constant. Both the JSON body and multipart form-data code paths now clamp `count` with `min(int(count), MAX_QUIZ_QUESTIONS)` before the value reaches the LLM prompt.
- **`app.py`**: Applied `@limiter.limit("10 per minute")` decorator to `generate_quiz` to throttle per-IP request volume.
- **`requirements.txt`**: Added `Flask-Limiter==3.5.0`.

---

## Screenshots / Demo (for UI changes)

Not applicable. This is a backend change with no UI impact.

---

## Checklist

- [x] Code follows project conventions and best practices.
- [x] Feature or fix works correctly on both mobile and desktop.
- [x] No new console errors or accessibility regressions.
- [x] Documentation updated if applicable.
- [x] Visuals attached for UI-related updates (not applicable here).

---

## Additional Notes

The rate limit (`10/min per IP`) and the question cap (`MAX_QUIZ_QUESTIONS = 20`) are both constants that can be adjusted without touching any other code. The in-memory storage backend is appropriate for a single-process deployment; if the app scales horizontally a Redis URI can be passed to `storage_uri` without any other changes.

---

Could you please add the appropriate **NSoC '26** label to this PR? It helps with tracking and scoring under NSoC '26. Thank you!