### PR TITLE
fix: resolve CGPA calculator visibility issue in light theme

### DIFF
--- a/assets/css/cgpa.css
+++ b/assets/css/cgpa.css
@@ -407,10 +407,12 @@ body {
 .calculate-btn {
     width: 100%;
     padding: 1.25rem;
-    background: linear-gradient(135deg, #009dff, #00c8ff);  /* Add gradient background */
+    background: linear-gradient(135deg, #009dff, #00c8ff);
+    /* Add gradient background */
     border: none;
     border-radius: 12px;
-    color: white;  /* Changed to white for better contrast */
+    color: white;
+    /* Changed to white for better contrast */
     font-size: 1.1rem;
     font-weight: 600;
     cursor: pointer;
@@ -1489,6 +1491,7 @@ body {
     .header-decoration {
         display: none;
     }
+
     /* Mobile styles for companies section */
     .companies-filter {
         justify-content: center;
@@ -1803,4 +1806,11 @@ input[type=number] {
 /* --- Error div --- */
 [data-theme="light"] #error {
     background-color: rgba(255, 68, 68, 0.07);
+}
+
+/* --- Icon wrapper (calculator icon beside the title) --- */
+[data-theme="light"] .icon-wrapper {
+    background: linear-gradient(135deg, #0369a1, #0ea5e9);
+    box-shadow: 0 4px 15px rgba(3, 105, 161, 0.25);
+    color: #ffffff;
 }


### PR DESCRIPTION
## Pull Request Summary
Fixes #304

This PR resolves the **CGPA Calculator visibility issue in Light Theme**. Certain UI elements had poor visibility and readability due to styling inconsistencies, affecting the user experience. The update improves contrast and ensures the calculator is clearly visible while maintaining compatibility with the existing Dark Theme.

---

## Changes Introduced
- Fixed visibility/readability issue in the CGPA Calculator for Light Theme  
- Updated styling in `assets/css/cgpa.css` to improve contrast and UI clarity  
- Preserved Dark Theme behavior without affecting existing functionality  

---

## Screenshots / Demo (for UI changes)

| Before | After |
|:-------:|:------:|
| <img width="1918" height="620" alt="image" src="https://github.com/user-attachments/assets/6152ac97-cae3-4445-8489-f438abe29117" /> | <img width="1911" height="1030" alt="image" src="https://github.com/user-attachments/assets/64b51747-0fca-4c71-b41c-1517fc1c8f4b" /> |

---

## Checklist
Please ensure the following before requesting review:
- [x] Code follows project conventions and best practices.  
- [x] Feature or fix works correctly on both mobile and desktop.  
- [x] No new console errors or accessibility regressions.  
- [ ] Documentation updated if applicable.  
- [x] Visuals attached for UI-related updates.  

---

## Additional Notes
This fix is limited to the CGPA Calculator Light Theme styling and does not affect Dark Theme behavior or other modules.