### PR TITLE
fix: resolve roadmap module hover visibility issue in Light Theme

### DIFF
--- a/roadmap_assets/css/sub-roadmap.css
+++ b/roadmap_assets/css/sub-roadmap.css
@@ -2378,6 +2378,11 @@ header {
     color: var(--text-muted) !important;
 }
 
+[data-theme="light"] .sidebar-link:hover {
+    background: rgba(0, 0, 0, 0.05);
+    color: var(--primary-color);
+}
+
 @media (max-width: 900px) {
     .dashboard-layout { grid-template-columns: 1fr; }
     .roadmap-sidebar { display: none; }


### PR DESCRIPTION
## Pull Request Summary
Fixes #305

This PR resolves the **Roadmap module hover visibility issue in Light Theme**. Some roadmap module cards/items became visually unclear or appeared blank on hover due to styling and contrast inconsistencies. The update improves readability and ensures a consistent hover experience in Light Theme while preserving Dark Theme behavior.

---

## Changes Introduced
- Fixed hover visibility issue in Roadmap module cards/items for Light Theme  
- Updated styling in `roadmap_assets/css/sub-roadmap.css` to improve contrast and readability  
- Preserved existing Dark Theme behavior without regressions  

---

## Screenshots / Demo (for UI changes)

| Before | After |
|:-------:|:------:|
| <img width="1899" height="940" alt="image" src="https://github.com/user-attachments/assets/5ef755f8-0952-4cb4-acaf-822d0b51d8df" /> | <img width="1898" height="887" alt="image" src="https://github.com/user-attachments/assets/fc28b8d6-f956-4020-9cbb-1974e04fded5" /> |

---

## Checklist
Please ensure the following before requesting review:
- [x] Code follows project conventions and best practices.  
- [x] Feature or fix works correctly on both mobile and desktop.  
- [x] No new console errors or accessibility regressions.  
- [ ] Documentation updated if applicable.  
- [x] Visuals attached for UI-related updates.  

---

## Additional Notes
This fix is limited to hover styling improvements for Roadmap module cards/items in Light Theme and does not affect existing functionality or Dark Theme behavior.